### PR TITLE
feat: add fictional teams JSON content

### DIFF
--- a/data/content/teams.json
+++ b/data/content/teams.json
@@ -61,8 +61,8 @@
       "factoryLevel": 55
     },
     {
-      "id": "emerald-gp-team",
-      "name": "Emerald GP Team",
+      "id": "emerald-racing-team",
+      "name": "Emerald Racing Team",
       "shortName": "EME",
       "primaryColor": "#006F62",
       "secondaryColor": "#00FF87",
@@ -91,8 +91,8 @@
       "factoryLevel": 40
     },
     {
-      "id": "alfie-gp",
-      "name": "Alfie GP",
+      "id": "team-alfie",
+      "name": "Team Alfie",
       "shortName": "ALF",
       "primaryColor": "#0090FF",
       "secondaryColor": "#FF87BC",


### PR DESCRIPTION
## Summary

- Adds `/data/content/teams.json` with 10 fictional F1 teams
- Each team has: id, name, shortName, colors, headquarters, budget, factoryLevel
- Budget and factory levels reflect competitive hierarchy (top teams ~$200M+, backmarkers ~$60M)

## Teams (in order of competitiveness)

| Team | HQ | Budget |
|------|-----|--------|
| Papaya Racing | UK | $220M |
| Silver Arrow Motorsport | Germany | $200M |
| Crimson Bull Racing | Austria | $195M |
| Scuderia Veloce | Italy | $190M |
| Willards GP Team | UK | $120M |
| Toro Minore | Italy | $100M |
| Emerald Racing Team | UK | $95M |
| Automation GP | USA | $90M |
| Sabre Grand Prix | Switzerland | $75M |
| Team Alfie | France | $60M |

## Test Plan

- [x] JSON is valid (parseable)
- [x] Matches `Team` interface from `@shared/domain`
- [x] Lint passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)