### PR TITLE
feat: add regulations config with full wiring

### DIFF
--- a/data/config/regulations.json
+++ b/data/config/regulations.json
@@ -1,0 +1,44 @@
+{
+  "seasons": [
+    {
+      "season": 1,
+      "testing": {
+        "maxMilesPerWeek": 350,
+        "preSeasonDays": 8
+      },
+      "engines": {
+        "unitsPerSeason": 8,
+        "gridPenaltyPerUnit": 5
+      },
+      "gearbox": {
+        "racesPerUnit": 6,
+        "gridPenalty": 5
+      },
+      "tyres": {
+        "compoundsPerWeekend": 2,
+        "drySetsPerWeekend": 13
+      },
+      "technologyCarryover": ["brakes", "clutch", "electronics", "gearbox"]
+    }
+  ],
+  "default": {
+    "season": 0,
+    "testing": {
+      "maxMilesPerWeek": 350,
+      "preSeasonDays": 8
+    },
+    "engines": {
+      "unitsPerSeason": 8,
+      "gridPenaltyPerUnit": 5
+    },
+    "gearbox": {
+      "racesPerUnit": 6,
+      "gridPenalty": 5
+    },
+    "tyres": {
+      "compoundsPerWeekend": 2,
+      "drySetsPerWeekend": 13
+    },
+    "technologyCarryover": ["brakes", "clutch", "electronics", "gearbox"]
+  }
+}

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -51,6 +51,14 @@ export function registerIpcHandlers(): void {
     return ConfigLoader.getRules();
   });
 
+  ipcMain.handle(IpcChannels.CONFIG_GET_REGULATIONS, () => {
+    return ConfigLoader.getRegulations();
+  });
+
+  ipcMain.handle(IpcChannels.CONFIG_GET_REGULATIONS_BY_SEASON, (_event, season: number) => {
+    return ConfigLoader.getRegulationsBySeason(season);
+  });
+
   // Game handlers (stubs for now)
   ipcMain.handle(IpcChannels.GAME_NEW, (_event, _teamId: string) => {
     // TODO: Implement when GameStateManager exists

--- a/src/shared/domain/types.ts
+++ b/src/shared/domain/types.ts
@@ -293,3 +293,41 @@ export interface GameRules {
   grid: GridConfig;
   raceWeekend: RaceWeekendConfig;
 }
+
+// =============================================================================
+// REGULATIONS TYPES (In-universe FIA rules, vary by season)
+// =============================================================================
+
+export interface TestingRegulations {
+  maxMilesPerWeek: number;
+  preSeasonDays: number;
+}
+
+export interface EngineRegulations {
+  unitsPerSeason: number;
+  gridPenaltyPerUnit: number;
+}
+
+export interface GearboxRegulations {
+  racesPerUnit: number;
+  gridPenalty: number;
+}
+
+export interface TyreRegulations {
+  compoundsPerWeekend: number;
+  drySetsPerWeekend: number;
+}
+
+export interface SeasonRegulations {
+  season: number;
+  testing: TestingRegulations;
+  engines: EngineRegulations;
+  gearbox: GearboxRegulations;
+  tyres: TyreRegulations;
+  technologyCarryover: string[]; // Component IDs that carry over between seasons
+}
+
+export interface Regulations {
+  seasons: SeasonRegulations[];
+  default: SeasonRegulations;
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -5,7 +5,17 @@
  * All IPC communication must go through these typed channels.
  */
 
-import type { Team, Driver, Circuit, Sponsor, Manufacturer, Chief, GameRules } from './domain';
+import type {
+  Team,
+  Driver,
+  Circuit,
+  Sponsor,
+  Manufacturer,
+  Chief,
+  GameRules,
+  Regulations,
+  SeasonRegulations,
+} from './domain';
 
 /** Channel names for IPC communication */
 export const IpcChannels = {
@@ -21,6 +31,8 @@ export const IpcChannels = {
   CONFIG_GET_MANUFACTURERS: 'config:getManufacturers',
   CONFIG_GET_CHIEFS: 'config:getChiefs',
   CONFIG_GET_RULES: 'config:getRules',
+  CONFIG_GET_REGULATIONS: 'config:getRegulations',
+  CONFIG_GET_REGULATIONS_BY_SEASON: 'config:getRegulationsBySeason',
 
   // Game state (placeholders for future implementation)
   GAME_NEW: 'game:new',
@@ -68,6 +80,14 @@ export interface IpcInvokeMap {
   [IpcChannels.CONFIG_GET_RULES]: {
     args: [];
     result: GameRules | null;
+  };
+  [IpcChannels.CONFIG_GET_REGULATIONS]: {
+    args: [];
+    result: Regulations | null;
+  };
+  [IpcChannels.CONFIG_GET_REGULATIONS_BY_SEASON]: {
+    args: [season: number];
+    result: SeasonRegulations | null;
   };
   [IpcChannels.GAME_NEW]: {
     args: [teamId: string];


### PR DESCRIPTION
## Summary
- Adds `Regulations` and `SeasonRegulations` TypeScript interfaces to types.ts
- Creates `/data/config/regulations.json` with season-based regulations + default fallback
- Full wiring: ConfigLoader, IPC channels, handlers

**Regulations structure (MVP-simple):**
| Category | Fields |
|----------|--------|
| Testing | maxMilesPerWeek, preSeasonDays |
| Engines | unitsPerSeason, gridPenaltyPerUnit |
| Gearbox | racesPerUnit, gridPenalty |
| Tyres | compoundsPerWeekend, drySetsPerWeekend |
| Tech | technologyCarryover (array of component IDs) |

**API:**
- `getRegulations()` - returns full Regulations object
- `getRegulationsBySeason(season)` - returns SeasonRegulations for specific season (falls back to default)

## Test plan
- [x] `yarn lint` passes
- [ ] Verify regulations.json loads via ConfigLoader

🤖 Generated with [Claude Code](https://claude.com/claude-code)