### PR TITLE
feat: wire GAME_NEW and GAME_GET_STATE IPC handlers

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -5,7 +5,8 @@
  */
 
 import { app, ipcMain } from 'electron';
-import { IpcChannels, NewGameIpcParams } from '../../shared/ipc';
+import { IpcChannels } from '../../shared/ipc';
+import type { NewGameParams } from '../../shared/domain';
 import { ConfigLoader } from '../services/config-loader';
 import { GameStateManager } from '../services/game-state-manager';
 
@@ -65,7 +66,7 @@ export function registerIpcHandlers(): void {
   });
 
   // Game state handlers
-  ipcMain.handle(IpcChannels.GAME_NEW, (_event, params: NewGameIpcParams) => {
+  ipcMain.handle(IpcChannels.GAME_NEW, (_event, params: NewGameParams) => {
     return GameStateManager.createNewGame(params);
   });
 

--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -30,6 +30,7 @@ import type {
   Chief,
   GameRules,
   SeasonRegulations,
+  NewGameParams,
 } from '../../shared/domain';
 import {
   GamePhase,
@@ -87,13 +88,6 @@ function assertNonEmpty<T>(array: T[], entityName: string): void {
  */
 function cloneDeep<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
-}
-
-/** Parameters for creating a new game */
-export interface NewGameParams {
-  playerName: string;
-  teamId: string;
-  seasonNumber?: number; // Defaults to DEFAULT_STARTING_SEASON
 }
 
 /**

--- a/src/shared/domain/types.ts
+++ b/src/shared/domain/types.ts
@@ -365,6 +365,20 @@ export interface CompoundsConfig {
 }
 
 // =============================================================================
+// GAME CREATION TYPES
+// =============================================================================
+
+/**
+ * NewGameParams - Parameters for creating a new game
+ * Used by both IPC layer and GameStateManager service
+ */
+export interface NewGameParams {
+  playerName: string;
+  teamId: string;
+  seasonNumber?: number;
+}
+
+// =============================================================================
 // GAME STATE TYPES
 // =============================================================================
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -17,14 +17,8 @@ import type {
   SeasonRegulations,
   TyreCompoundConfig,
   GameState,
+  NewGameParams,
 } from './domain';
-
-/** Parameters for creating a new game via IPC */
-export interface NewGameIpcParams {
-  playerName: string;
-  teamId: string;
-  seasonNumber?: number;
-}
 
 /** Channel names for IPC communication */
 export const IpcChannels = {
@@ -44,11 +38,12 @@ export const IpcChannels = {
   CONFIG_GET_REGULATIONS_BY_SEASON: 'config:getRegulationsBySeason',
   CONFIG_GET_COMPOUNDS: 'config:getCompounds',
 
-  // Game state (placeholders for future implementation)
+  // Game state
   GAME_NEW: 'game:new',
+  GAME_GET_STATE: 'game:getState',
+  // Save/load (placeholders for future implementation)
   GAME_SAVE: 'game:save',
   GAME_LOAD: 'game:load',
-  GAME_GET_STATE: 'game:getState',
 } as const;
 
 export type IpcChannel = (typeof IpcChannels)[keyof typeof IpcChannels];
@@ -104,7 +99,7 @@ export interface IpcInvokeMap {
     result: TyreCompoundConfig[];
   };
   [IpcChannels.GAME_NEW]: {
-    args: [params: NewGameIpcParams];
+    args: [params: NewGameParams];
     result: GameState;
   };
   [IpcChannels.GAME_SAVE]: {


### PR DESCRIPTION
## Summary

- Add `NewGameIpcParams` interface for typed IPC calls
- Update `GAME_NEW` handler to call `GameStateManager.createNewGame()`
- Update `GAME_GET_STATE` handler to call `GameStateManager.getCurrentState()`
- Fix IPC types: `GAME_NEW` returns `GameState`, `GAME_GET_STATE` returns `GameState | null`

## Test plan

- [ ] Verify lint passes
- [ ] Manual test: call `window.electronAPI.invoke('game:new', { playerName: 'Test', teamId: 'veloce' })` in devtools
- [ ] Verify game state is returned and accessible via `window.electronAPI.invoke('game:getState')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)