### PR TITLE
feat: add drivers column to team selection screen

### DIFF
--- a/src/renderer/screens/TeamSelectScreen.tsx
+++ b/src/renderer/screens/TeamSelectScreen.tsx
@@ -51,6 +51,22 @@ function formatBudget(budget: number): string {
 }
 
 /**
+ * Get sort priority for driver role (lower = higher priority)
+ */
+function getDriverRolePriority(role: DriverRole): number {
+  switch (role) {
+    case DriverRole.First:
+      return 0;
+    case DriverRole.Second:
+      return 1;
+    case DriverRole.Equal:
+      return 2;
+    case DriverRole.Test:
+      return 3;
+  }
+}
+
+/**
  * Format driver role for display
  */
 function formatDriverRole(role: DriverRole): string {
@@ -111,9 +127,11 @@ export function TeamSelectScreen() {
     }
   }, [playerName]);
 
-  // Get drivers for selected team
+  // Get drivers for selected team, sorted by role (#1 first, then #2, etc.)
   const teamDrivers = selectedTeam
-    ? drivers.filter((d) => d.teamId === selectedTeam.id)
+    ? drivers
+        .filter((d) => d.teamId === selectedTeam.id)
+        .sort((a, b) => getDriverRolePriority(a.role) - getDriverRolePriority(b.role))
     : [];
 
   // Handle starting the game
@@ -143,7 +161,7 @@ export function TeamSelectScreen() {
   if (isLoading) {
     return (
       <div className="team-select-screen flex items-center justify-center min-h-screen bg-gray-800">
-        <p className="text-white">Loading teams...</p>
+        <p className="text-white">Loading...</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Add middle column showing drivers for selected team
- Fetch all drivers via `CONFIG_GET_DRIVERS` IPC (parallel with teams)
- Filter drivers by `teamId` to show only selected team's drivers
- Display driver cards with name and role (first/second/equal driver)

## Implementation Details
GPW-faithful 3-column layout per `proposal.md`:
- Left: Team list
- Middle: Drivers for selected team (NEW)
- Right: Team details

Driver cards show:
- Full name (firstName + lastName)
- Role designation (e.g., "First driver", "Second driver")

No photos yet - that's PR E (Asset Integration).

## Test Plan
- [ ] Run `yarn start`
- [ ] Navigate to team selection screen
- [ ] Verify drivers column appears between team list and details
- [ ] Click different teams → verify drivers update to show that team's drivers
- [ ] Verify driver names and roles display correctly
- [ ] Teams with no drivers show "No drivers assigned" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)