### PR TITLE
feat: add ITurnEngine interface and time progression types

### DIFF
--- a/src/shared/domain/engines.ts
+++ b/src/shared/domain/engines.ts
@@ -206,6 +206,14 @@ interface ProgressionChanges {
 }
 
 /**
+ * RaceWeekInfo - Details about an upcoming race week
+ * Present when the next week is a race week, null otherwise
+ */
+export interface RaceWeekInfo {
+  circuitId: string;
+}
+
+/**
  * TurnProcessingResult - Result of processing a weekly turn
  *
  * If `blocked` is set, the turn could not progress and the caller should:
@@ -216,8 +224,7 @@ interface ProgressionChanges {
 export interface TurnProcessingResult extends StateChanges, ProgressionChanges {
   newDate: GameDate;
   newPhase: GamePhase;
-  isRaceWeek: boolean;
-  raceCircuitId?: string; // Set if isRaceWeek is true
+  raceWeek: RaceWeekInfo | null;
   blocked?: TurnBlocked;
 }
 


### PR DESCRIPTION
## Summary
- Add `ITurnEngine` interface with 3 methods: `processWeek`, `processRace`, `processSeasonEnd`
- Add comprehensive input/output types for all turn processing operations
- Foundation for the time progression system (PR 1 of 8)

## Types Added
- `TurnProcessingInput` / `TurnProcessingResult` - Weekly turn processing
- `RaceProcessingInput` / `RaceProcessingResult` - Post-race state updates
- `SeasonEndInput` / `SeasonEndResult` - End of season processing
- `DriverStateChange` - Driver runtime state changes (fatigue, morale, etc.)
- `DriverAttributeChange` - Driver permanent attribute changes (aging)
- `ChiefChange` - Chief ability and retirement changes
- `TeamStateChange` - Team budget, morale, sponsor satisfaction changes

## Test plan
- [x] `yarn lint` passes
- [ ] Types are importable from `src/shared/domain/engines.ts`
- [ ] No TypeScript errors when implementing StubTurnEngine (next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)