### PR TITLE
feat: implement processRace in StubTurnEngine

### DIFF
--- a/src/main/engines/stubs.ts
+++ b/src/main/engines/stubs.ts
@@ -331,6 +331,31 @@ function calculateFinishMorale(
 }
 
 /**
+ * Shared stats present in both driver and constructor standings
+ */
+interface CommonStandingStats {
+  wins: number;
+  podiums: number;
+  polePositions: number;
+}
+
+/**
+ * Update common standing stats (wins, podiums, pole positions) based on race result
+ * Used by both driver and constructor standings updates
+ */
+function updateCommonStats(standing: CommonStandingStats, result: DriverRaceResult): void {
+  if (result.finishPosition === 1) {
+    standing.wins += 1;
+  }
+  if (isPodium(result.finishPosition)) {
+    standing.podiums += 1;
+  }
+  if (result.gridPosition === 1) {
+    standing.polePositions += 1;
+  }
+}
+
+/**
  * Sort standings by points (descending), then wins as tiebreaker
  * Also assigns position numbers based on sorted order
  * Returns a new array with new objects (pure function, no mutation)
@@ -386,16 +411,10 @@ function updateDriverStandings(
     // Add points
     standing.points += result.points;
 
-    // Update stats
-    if (result.finishPosition === 1) {
-      standing.wins += 1;
-    }
-    if (isPodium(result.finishPosition)) {
-      standing.podiums += 1;
-    }
-    if (result.gridPosition === 1) {
-      standing.polePositions += 1;
-    }
+    // Update common stats (wins, podiums, poles)
+    updateCommonStats(standing, result);
+
+    // Update driver-specific stats
     if (result.fastestLap) {
       standing.fastestLaps += 1;
     }
@@ -442,15 +461,7 @@ function updateConstructorStandings(
     standing.points += result.points;
 
     // Update stats (any driver achieving these counts for team)
-    if (result.finishPosition === 1) {
-      standing.wins += 1;
-    }
-    if (isPodium(result.finishPosition)) {
-      standing.podiums += 1;
-    }
-    if (result.gridPosition === 1) {
-      standing.polePositions += 1;
-    }
+    updateCommonStats(standing, result);
   }
 
   return sortAndAssignPositions(Array.from(standingsMap.values()));


### PR DESCRIPTION
## Summary

- Implements `StubTurnEngine.processRace()` to process race results
- Updates driver and constructor championship standings with points, wins, podiums, poles, fastest laps, and DNFs
- Generates driver state changes: morale and reputation based on finish position
- Generates team state changes: budget bonuses for points scored, morale boosts for engineering/mechanics

## Details

**Standings Updates:**
- Driver standings: adds points, increments wins/podiums/poles/fastest laps/DNFs
- Constructor standings: aggregates team driver points and stats
- Both sorted by points (descending), wins as tiebreaker

**Driver State Changes:**
- Win: +10 morale, +3 reputation
- Podium (non-win): +5 morale, +1 reputation
- Points (non-podium): +2 morale
- DNF: -5 morale, -1 reputation

**Team State Changes:**
- Budget: +$10,000 per championship point earned
- Morale: Engineering and Mechanics departments get same morale boost as best-finishing driver

## Test plan

- [ ] Code compiles (`yarn lint` passes)
- [ ] Run a race in the game and verify standings update correctly
- [ ] Check driver morale/reputation change after race
- [ ] Verify team budget increases with points finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)