### PR TITLE
feat: implement processSeasonEnd in StubTurnEngine

### DIFF
--- a/src/main/engines/stubs.ts
+++ b/src/main/engines/stubs.ts
@@ -345,6 +345,20 @@ const SEASON_START_MORALE = 70; // Neutral-positive morale at season start
 const SEASON_START_FITNESS = 100; // Full fitness at season start
 
 /**
+ * Initial driver runtime state for start of new season
+ */
+const INITIAL_DRIVER_RUNTIME_STATE: Partial<DriverRuntimeState> = {
+  fatigue: 0,
+  fitness: SEASON_START_FITNESS,
+  morale: SEASON_START_MORALE,
+  engineUnitsUsed: 0,
+  gearboxRaceCount: 0,
+  injuryWeeksRemaining: 0,
+  banRacesRemaining: 0,
+  isAngry: false,
+};
+
+/**
  * Check if a race result counts as a DNF (did not finish normally)
  */
 function isDNF(status: RaceFinishStatus): boolean {
@@ -844,22 +858,9 @@ function generateNewCalendar(circuits: Circuit[]): CalendarEntry[] {
 function generateResetDriverStates(
   drivers: Driver[]
 ): Record<string, Partial<DriverRuntimeState>> {
-  const resets: Record<string, Partial<DriverRuntimeState>> = {};
-
-  for (const driver of drivers) {
-    resets[driver.id] = {
-      fatigue: 0,
-      fitness: SEASON_START_FITNESS,
-      morale: SEASON_START_MORALE,
-      engineUnitsUsed: 0,
-      gearboxRaceCount: 0,
-      injuryWeeksRemaining: 0,
-      banRacesRemaining: 0,
-      isAngry: false,
-    };
-  }
-
-  return resets;
+  return Object.fromEntries(
+    drivers.map((driver) => [driver.id, { ...INITIAL_DRIVER_RUNTIME_STATE }])
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Implements `processSeasonEnd()` in StubTurnEngine (PR 4 of Core Game Loop)
- Handles end-of-season processing: driver aging, chief ability changes, retirements, new calendar generation, and state resets

## What This PR Does

**Driver Aging:**
- Young drivers (<28) have a chance to improve 1-2 attributes
- Peak age drivers (28-31) have no changes
- Older drivers (32+) experience attribute decline with increasing probability

**Chief Changes:**
- 50% chance per season for small ability fluctuations (+/- 2)

**Retirements:**
- Drivers: Linear probability between ages 35-42
- Chiefs: Estimated age based on ability, retire between 55-70

**New Calendar:**
- Generates shuffled calendar from circuits
- Distributes races evenly across weeks 10-48

**State Resets:**
- Resets fatigue, fitness, morale for all drivers
- Clears injuries, bans, and component usage counts

## Test Plan

- [ ] Code review for logic correctness
- [ ] Verify lint passes
- [ ] Manual testing when frontend wiring is complete (PR 5-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)