### PR TITLE
fix: stop autosave timer when clearing game state

### DIFF
--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -74,6 +74,10 @@ export function registerIpcHandlers(): void {
     return GameStateManager.getCurrentState();
   });
 
+  ipcMain.handle(IpcChannels.GAME_CLEAR_STATE, () => {
+    GameStateManager.clearState();
+  });
+
   ipcMain.handle(IpcChannels.GAME_ADVANCE_WEEK, () => {
     return GameStateManager.advanceWeek();
   });

--- a/src/renderer/hooks/useIpc.ts
+++ b/src/renderer/hooks/useIpc.ts
@@ -244,14 +244,15 @@ export function useInvalidateGameState() {
 }
 
 /**
- * Clear game state from cache - used when restarting/exiting
+ * Clear game state from both main process and cache - used when restarting/exiting
+ * Stops the autosave timer and clears all game state
  */
 export function useClearGameState() {
   const queryClient = useQueryClient();
-  return useCallback(
-    () => queryClient.setQueryData(queryKeys.gameState, null),
-    [queryClient]
-  );
+  return useCallback(() => {
+    window.electronAPI.invoke(IpcChannels.GAME_CLEAR_STATE);
+    queryClient.setQueryData(queryKeys.gameState, null);
+  }, [queryClient]);
 }
 
 /**

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -104,6 +104,7 @@ export const IpcChannels = {
   // Game state
   GAME_NEW: 'game:new',
   GAME_GET_STATE: 'game:getState',
+  GAME_CLEAR_STATE: 'game:clearState',
   GAME_ADVANCE_WEEK: 'game:advanceWeek',
   GAME_NEW_SEASON: 'game:newSeason',
 
@@ -186,6 +187,10 @@ export interface IpcInvokeMap {
   [IpcChannels.GAME_GET_STATE]: {
     args: [];
     result: GameState | null;
+  };
+  [IpcChannels.GAME_CLEAR_STATE]: {
+    args: [];
+    result: void;
   };
   [IpcChannels.GAME_ADVANCE_WEEK]: {
     args: [];


### PR DESCRIPTION
## Summary
- Added `GAME_CLEAR_STATE` IPC channel to properly clear main process game state
- Updated `useClearGameState()` to call the main process (stops autosave timer) in addition to clearing renderer cache

## Problem
When clicking "Restart" to return to the title screen, only the renderer's React Query cache was cleared. The main process still had `GameStateManager.currentState` set and the autosave timer kept running. This caused autosave notifications to appear even when no game was "loaded" from the user's perspective.

## Test plan
- [ ] Start a new game
- [ ] Wait for autosave to trigger (5 min) or manually verify timer is running
- [ ] Click Restart to return to title screen
- [ ] Wait 5+ minutes - verify no autosave notification appears
- [ ] Start/load a new game - verify autosave works again

🤖 Generated with [Claude Code](https://claude.com/claude-code)