### PR TITLE
feat: emit CAREER_STARTED event on new game

### DIFF
--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -68,6 +68,9 @@ import {
   ManufacturerType,
   ManufacturerDealType,
   hasRaceSeat,
+  createEvent,
+  managerRef,
+  teamRef,
 } from '../../shared/domain';
 import {
   getPreSeasonStartDate,
@@ -1179,6 +1182,16 @@ export const GameStateManager = {
       rules: cloneDeep(rules),
       regulations: cloneDeep(regulations),
     });
+
+    // Emit CAREER_STARTED event
+    const careerStartedEvent = createEvent({
+      type: 'CAREER_STARTED',
+      date: gameState.currentDate,
+      involvedEntities: [managerRef(), teamRef(teamId)],
+      data: { playerName, teamId, seasonNumber },
+      importance: 'high',
+    });
+    gameState.events.push(careerStartedEvent);
 
     // Store as current state
     GameStateManager.currentState = gameState;


### PR DESCRIPTION
## Summary

- Emits `CAREER_STARTED` event when a new game is created
- Includes player name, team ID, and season number in event data
- Event involves both the player manager and chosen team entities

This is PR 3 of the Events Infrastructure series. It enables the Player Wiki and other event consumers to track career history from the very start.

## Test plan

- [ ] Start a new game
- [ ] Query events via IPC (`EVENTS_QUERY`) or check game state
- [ ] Verify `CAREER_STARTED` event exists with correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)