### PR TITLE
feat: add Player Wiki biography prose view

### DIFF
--- a/src/renderer/content/PlayerWiki.tsx
+++ b/src/renderer/content/PlayerWiki.tsx
@@ -506,30 +506,22 @@ export function PlayerWiki() {
     gameState.currentDate.year
   );
 
+  const careerViewProps: CareerViewProps = {
+    playerName: careerData.playerName,
+    careerStartDate: careerEvent.date,
+    startingTeamName,
+    currentTeamName: playerTeam.name,
+    seasonsPlayed,
+  };
+
   const renderTabContent = () => {
     switch (activeTab) {
       case 'stats':
-        return (
-          <CareerStats
-            playerName={careerData.playerName}
-            careerStartDate={careerEvent.date}
-            startingTeamName={startingTeamName}
-            currentTeamName={playerTeam.name}
-            seasonsPlayed={seasonsPlayed}
-          />
-        );
+        return <CareerStats {...careerViewProps} />;
       case 'timeline':
         return <CareerTimeline events={allEvents} teams={gameState.teams} />;
       case 'biography':
-        return (
-          <CareerBiography
-            playerName={careerData.playerName}
-            careerStartDate={careerEvent.date}
-            startingTeamName={startingTeamName}
-            currentTeamName={playerTeam.name}
-            seasonsPlayed={seasonsPlayed}
-          />
-        );
+        return <CareerBiography {...careerViewProps} />;
     }
   };
 


### PR DESCRIPTION
## Summary
- Implements the Biography tab in Player Wiki with Wikipedia-style narrative prose
- Generates dynamic text based on career events (player name, start date, team, seasons)
- Adds prose generation helpers: `formatDateForProse`, `generateOpeningParagraph`, `generateCareerBeginnings`, `generateStatisticsSummary`
- Adds `BiographySection` and `ProseParagraph` components for structured article layout
- Supports markdown-style bold (**text**) in prose for emphasis

## Test plan
- [ ] Load existing save or start new game
- [ ] Navigate to TEAM > Player Wiki
- [ ] Click "Biography" tab
- [ ] Verify opening paragraph shows player name (bold), start date, team
- [ ] Verify "Career Beginnings" section appears with contextual text
- [ ] Verify "Career Statistics" section appears with placeholder message
- [ ] Advance time (or test with different game states) to verify season count updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)