### PR TITLE
feat: add design system types and state

### DIFF
--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -254,10 +254,6 @@ function createInitialTeamState(
     sponsorSatisfaction,
     staffCounts: cloneDeep(initialStaffCounts),
     setupPoints: 0,
-    developmentTesting: {
-      handlingPercentage: 0,
-      handlingProblemsFound: [],
-    },
     designState: createInitialDesignState(),
   };
 }

--- a/src/renderer/content/TeamProfile.tsx
+++ b/src/renderer/content/TeamProfile.tsx
@@ -215,24 +215,25 @@ interface DevelopmentTestingSectionProps {
 }
 
 function DevelopmentTestingSection({ teamState }: DevelopmentTestingSectionProps) {
-  const { handlingPercentage, handlingProblemsFound } = teamState.developmentTesting;
+  const { handlingRevealed, problems } = teamState.designState.currentYearChassis;
+  const discoveredProblems = problems.filter((p) => p.discovered);
 
   return (
     <div className="card p-5" style={ACCENT_CARD_STYLE}>
       <div className="flex items-center gap-4 mb-2">
         <span className="text-base font-medium text-secondary">Handling Knowledge</span>
         <ProgressBar
-          value={handlingPercentage}
+          value={handlingRevealed}
           colorClass="bg-[var(--accent-500)]"
           glow="0 0 8px color-mix(in srgb, var(--accent-500) 50%, transparent)"
         />
         <span className="text-base font-bold tabular-nums" style={ACCENT_TEXT_STYLE}>
-          {handlingPercentage}%
+          {handlingRevealed}%
         </span>
       </div>
-      {handlingProblemsFound.length > 0 && (
+      {discoveredProblems.length > 0 && (
         <div className="text-sm text-muted">
-          Problems found: {handlingProblemsFound.join(', ')}
+          Problems found: {discoveredProblems.map((p) => p.problem).join(', ')}
         </div>
       )}
     </div>

--- a/src/shared/domain/types.ts
+++ b/src/shared/domain/types.ts
@@ -932,15 +932,6 @@ export interface DriverRuntimeState {
 export type DepartmentMorale = Record<Department, number>;
 
 /**
- * DevelopmentTestingState - Progress tracking for development testing
- * Reveals handling characteristics through test sessions
- */
-export interface DevelopmentTestingState {
-  handlingPercentage: number; // 0-100, how much is revealed (0 = unknown)
-  handlingProblemsFound: string[]; // Problem IDs discovered
-}
-
-/**
  * TeamRuntimeState - Mutable state for a team during gameplay
  * Keyed by teamId in GameState.teamStates
  */
@@ -951,10 +942,9 @@ export interface TeamRuntimeState {
   sponsorSatisfaction: Record<string, number>;
   // Staff counts by department and quality (GPW-style anonymous pools)
   staffCounts: DepartmentStaffCounts;
-  // Testing progress
+  // Testing progress (setup points for Set-Up Testing)
   setupPoints: number; // Accumulated from set-up testing
-  developmentTesting: DevelopmentTestingState;
-  // Design department state (chassis, technology, improvements)
+  // Design department state (chassis, technology, improvements, handling)
   designState: DesignState;
 }
 


### PR DESCRIPTION
## Summary

- Add Design System types to `types.ts`:
  - `ChassisDesignStage` enum (Design, CFD, Model, WindTunnel)
  - `TechnologyComponent` enum (7 components: Brakes, Clutch, Electronics, Gearbox, Hydraulics, Suspension, Throttle)
  - `TechnologyAttribute` enum (Performance, Reliability)
  - `HandlingProblem` enum (8 problems: OversteerFast/Slow, UndersteerFast/Slow, HighDrag, PoorBalance, LowDownforce, HighPitchSensitivity)
  - `ChassisDesign`, `TechnologyLevel`, `TechnologyDesignProject`, `HandlingProblemState`, `CurrentYearChassisState`, `DesignState` interfaces
- Add `designState: DesignState` to `TeamRuntimeState`
- Initialize design state in new game creation with helper functions

## Test plan

- [ ] Start a new game - should initialize without errors
- [ ] Check browser DevTools: `window.electronAPI.invoke('game:state').then(s => console.log(s.teamStates['mclaren'].designState))` should show design state with 7 technology components at level 3/3 and 8 handling problems all undiscovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)