### PR TITLE
refactor: redesign TeamProfile with championship stats

### DIFF
--- a/src/renderer/content/TeamProfile.tsx
+++ b/src/renderer/content/TeamProfile.tsx
@@ -32,6 +32,10 @@ function formatContractEnd(seasonNumber: number): string {
   return `31 Dec ${year}`;
 }
 
+function formatContractLine(salary: number, contractEnd: number): string {
+  return `${formatAnnualSalary(salary)} · Contract ends ${formatContractEnd(contractEnd)}`;
+}
+
 // ===========================================
 // SHARED COMPONENTS
 // ===========================================
@@ -68,11 +72,11 @@ function StatCard({ label, value, accent = false }: StatCardProps) {
 // DRIVER & CHIEF CARDS
 // ===========================================
 
-function MiniStat({ value, label }: { value: React.ReactNode; label: string }) {
+function MiniStat({ value, label }: { value: React.ReactNode; label?: string }) {
   return (
     <div className="text-muted">
       <span className="font-medium text-secondary">{value}</span>
-      <span className="ml-1">{label}</span>
+      {label && <span className="ml-1">{label}</span>}
     </div>
   );
 }
@@ -109,13 +113,13 @@ function DriverCard({ driver, standing }: DriverCardProps) {
         </div>
         {/* Championship Stats */}
         <div className="flex gap-4 mt-2 text-xs">
-          <MiniStat value={standing ? formatOrdinal(standing.position) : '-'} label="" />
+          <MiniStat value={standing ? formatOrdinal(standing.position) : '-'} />
           <MiniStat value={standing?.points ?? 0} label="Pts" />
           <MiniStat value={standing?.wins ?? 0} label="Wins" />
         </div>
         {/* Contract Info */}
         <div className="text-xs text-muted mt-1">
-          {formatAnnualSalary(driver.salary)} · Contract ends {formatContractEnd(driver.contractEnd)}
+          {formatContractLine(driver.salary, driver.contractEnd)}
         </div>
       </div>
     </div>
@@ -137,7 +141,7 @@ function ChiefCard({ chief }: ChiefCardProps) {
       </div>
       <div className="text-xs text-muted mt-2 space-y-0.5">
         <div>Ability: {chief.ability}</div>
-        <div>{formatAnnualSalary(chief.salary)} · Contract ends {formatContractEnd(chief.contractEnd)}</div>
+        <div>{formatContractLine(chief.salary, chief.contractEnd)}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Redesigned Team Profile screen following GPW reference layout
- Added championship stats (Position, Points, Wins) to stat cards row
- Added HQ location with country flag in header area
- Updated Driver cards with championship stats (position, points, wins) and nationality flag
- Updated Chief cards with contract duration info
- Removed: Department Morale, Staff counts, Development Testing sections

## Test plan
- [ ] Navigate to Team Profile screen
- [ ] Verify stat cards show Budget (accent), Championship position, Points, Wins
- [ ] Verify HQ flag displays correctly in header
- [ ] Verify driver cards show position/points/wins and contract info
- [ ] Verify chief cards show ability and contract duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)