### PR TITLE
feat: add World section, move News from Team to World

### DIFF
--- a/src/renderer/components/MainLayout.tsx
+++ b/src/renderer/components/MainLayout.tsx
@@ -151,7 +151,7 @@ export function MainLayout() {
       return <TeamProfile />;
     }
 
-    if (selectedSectionId === 'team' && selectedSubItemId === 'news') {
+    if (selectedSectionId === 'world' && selectedSubItemId === 'news') {
       return <News />;
     }
 

--- a/src/renderer/navigation.ts
+++ b/src/renderer/navigation.ts
@@ -29,10 +29,13 @@ import {
   Settings,
   RotateCcw,
   LogOut,
+  Globe,
+  User,
+  LineChart,
   type LucideIcon,
 } from 'lucide-react';
 
-export type SectionId = 'team' | 'engineering' | 'commercial' | 'racing' | 'fia' | 'options';
+export type SectionId = 'team' | 'world' | 'engineering' | 'commercial' | 'racing' | 'fia' | 'options';
 
 export interface SubItem {
   id: string;
@@ -54,11 +57,22 @@ export const sections: Section[] = [
     icon: Users,
     subItems: [
       { id: 'profile', label: 'Profile', icon: Users },
-      { id: 'news', label: 'News', icon: Newspaper },
       { id: 'mail', label: 'Mail', icon: Mail },
       { id: 'finance', label: 'Finance', icon: DollarSign },
       { id: 'staff', label: 'Staff', icon: UserCog },
       { id: 'wiki', label: 'Player Wiki', icon: BookUser },
+    ],
+  },
+  {
+    id: 'world',
+    label: 'WORLD',
+    icon: Globe,
+    subItems: [
+      { id: 'news', label: 'News', icon: Newspaper },
+      { id: 'teams', label: 'Teams', icon: Users },
+      { id: 'drivers', label: 'Drivers', icon: User },
+      { id: 'staff', label: 'Staff', icon: UserCog },
+      { id: 'stats', label: 'Stats', icon: LineChart },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Add new WORLD section to sidebar navigation (after TEAM)
- Move News from TEAM section to WORLD section
- Add placeholder sub-items: Teams, Drivers, Staff, Stats (to be implemented in future PRs)

## Part of Plan
This is PR #2 from `agents/plan.md` - World Section + Global Navigation System.

## Test plan
- [ ] Open the game and verify WORLD section appears in sidebar
- [ ] Verify News is accessible under WORLD > News
- [ ] Verify News is no longer under TEAM section
- [ ] Verify other World sub-items show "Coming soon" placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)