### PR TITLE
refactor: simplify renderContent() routing in MainLayout

### DIFF
--- a/src/renderer/components/MainLayout.tsx
+++ b/src/renderer/components/MainLayout.tsx
@@ -37,6 +37,10 @@ import {
   Results,
   RaceWeekend,
 } from '../content';
+import { GamePhase } from '../../shared/domain';
+import { RoutePaths } from '../routes';
+
+type ActiveDialog = ActionType | null;
 
 // Route map for simple components (no props needed)
 const ROUTE_COMPONENTS: Partial<Record<SectionId, Record<string, React.ComponentType>>> = {
@@ -62,10 +66,6 @@ const ROUTE_COMPONENTS: Partial<Record<SectionId, Record<string, React.Component
     'game-options': GameOptions,
   },
 };
-import { GamePhase } from '../../shared/domain';
-import { RoutePaths } from '../routes';
-
-type ActiveDialog = ActionType | null;
 
 export function MainLayout() {
   const [selectedSectionId, setSelectedSectionId] = useState<SectionId>(defaultSection);


### PR DESCRIPTION
## Summary

Closes #85

- Replaced repetitive if-else chains in `renderContent()` with a `ROUTE_COMPONENTS` map for simple routes
- Routes with props (Results, Races, SavedGames, ActionScreen) remain as explicit conditionals for clarity
- Net reduction of ~17 lines while improving maintainability

## Test plan

- [ ] Navigate to all Team sub-items (profile, mail, finance, staff, wiki)
- [ ] Navigate to World > News
- [ ] Navigate to Engineering sub-items (cars, factory, design)
- [ ] Navigate to FIA sub-items (championship, races, results)
- [ ] Navigate to Options sub-items (saved-games, game-options, restart, quit)
- [ ] Verify "Coming soon" fallback appears for unimplemented routes