### PR TITLE
feat: add design news headlines for AI team milestones

### DIFF
--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -1094,17 +1094,16 @@ function applyDesignUpdates(
       playerHadMilestone = true;
     }
 
-    // For non-player teams with milestones, generate news headlines
-    if (!isPlayerTeam && hasMilestones(update)) {
-      const team = state.teams.find((t) => t.id === update.teamId);
-      if (team) {
-        generateDesignNewsForTeam(state, update, currentDate, team.name);
+    // For non-player teams: generate news headlines if they have milestones, then skip
+    if (!isPlayerTeam) {
+      if (hasMilestones(update)) {
+        const team = state.teams.find((t) => t.id === update.teamId);
+        if (team) {
+          generateDesignNewsForTeam(state, update, currentDate, team.name);
+        }
       }
       continue;
     }
-
-    // Only create emails for player's team
-    if (!isPlayerTeam) continue;
 
     // Get the Chief Designer for sender
     const chiefDesigner = state.chiefs.find(


### PR DESCRIPTION
## Summary

- Adds news headline generation for AI team design milestones
- Creates headlines for: chassis stage completions, technology breakthroughs, technology upgrades, and handling solutions
- Headlines appear in the News screen with team-specific messaging
- Non-blocking (critical: false) - doesn't stop simulation

**Note:** Headlines will only appear once AI team allocation logic is implemented (future PR). The infrastructure is now in place.

## Test plan

- [ ] Start a new game
- [ ] Verify no errors during time advancement
- [ ] Once AI allocations are implemented, verify news headlines appear for AI team milestones

🤖 Generated with [Claude Code](https://claude.com/claude-code)