### PR TITLE
feat: add contracts negotiation tab UI

### DIFF
--- a/src/renderer/content/Contracts.tsx
+++ b/src/renderer/content/Contracts.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback } from 'react';
 import { useDerivedGameState } from '../hooks';
 import { SectionHeading, TabBar } from '../components';
 import type { Tab } from '../components';
-import { ACCENT_CARD_STYLE, GHOST_BORDERED_BUTTON_CLASSES } from '../utils/theme-styles';
+import { ACCENT_CARD_STYLE, GHOST_BORDERED_BUTTON_CLASSES, PRIMARY_BUTTON_CLASSES } from '../utils/theme-styles';
 import { formatMoney } from '../utils/format';
 import { seasonToYear } from '../../shared/utils/date-utils';
 import { IpcChannels } from '../../shared/ipc';
@@ -704,7 +704,7 @@ function ActiveNegotiationCard({
           <div className="flex gap-2">
             <button
               type="button"
-              className="flex-1 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg font-medium cursor-pointer"
+              className={`${PRIMARY_BUTTON_CLASSES} flex-1 cursor-pointer`}
               onClick={() => onRespondToOffer(latestOffer.id, 'accept')}
             >
               Accept Offer


### PR DESCRIPTION
## Summary

- Implements the Negotiation tab UI for the Contracts screen
- Lists all engine manufacturers with reputation and base price
- Shows "Current" badge on player's current engine supplier
- Start Negotiation button initiates negotiations
- Displays active negotiations with status indicators
- Shows offer details when manufacturer responds (annual cost, duration, upgrades, customisation points, optimisation)
- Accept/Reject buttons for responding to offers
- Contract expiring warning banner when current contract ends this season

## PR 7 of Engine Supplier Contracts System

This PR completes the UI for the negotiation system. It connects to the backend handlers from PR 6.

### Components Added
- `NegotiationTab` - Main tab component
- `ManufacturerRow` - Table row for each manufacturer
- `ActiveNegotiationCard` - Card showing negotiation status and offers
- `getNegotiationStatusDisplay` - Helper for status labels and colors

### IPC Handlers Used
- `engine:startNegotiation` - Start a negotiation
- `engine:respondToOffer` - Accept or reject an offer

## Test Plan

- [ ] Navigate to Engineering > Contracts > Negotiation tab
- [ ] Verify all engine manufacturers are listed
- [ ] Verify "Current" badge appears on current supplier
- [ ] Click "Start Negotiation" and verify state updates
- [ ] Verify active negotiations display with correct status

🤖 Generated with [Claude Code](https://claude.com/claude-code)