### PR TITLE
feat: add generic negotiation types

### DIFF
--- a/src/shared/domain/types.ts
+++ b/src/shared/domain/types.ts
@@ -1450,20 +1450,9 @@ export interface SponsorContractTerms {
 
 /**
  * EngineContractTerms - Contract terms for engine supply
- * (Alias for existing ContractTerms for backwards compatibility)
+ * Type alias for existing ContractTerms (legacy type defined below)
  */
-export interface EngineContractTerms {
-  /** Annual fee (positive = team pays, negative = works deal pays team) */
-  annualCost: number;
-  /** Contract duration in seasons */
-  duration: number;
-  /** Pre-paid engine upgrades included per season */
-  upgradesIncluded: number;
-  /** Customisation points included */
-  customisationPointsIncluded: number;
-  /** Whether optimisation package is included */
-  optimisationIncluded: boolean;
-}
+export type EngineContractTerms = ContractTerms;
 
 /**
  * AnyContractTerms - Union of all stakeholder-specific contract terms


### PR DESCRIPTION
## Summary

Adds the foundation types for the generic negotiation system that will handle all contract types (drivers, staff, sponsors, engine suppliers).

**New Types Added:**
- `StakeholderType` enum - manufacturer, driver, staff, sponsor
- `NegotiationPhase` enum - state machine (awaiting-response, response-received, completed, failed)
- `ResponseType` enum - accept, counter, reject, need-time
- `ResponseTone` enum - enthusiastic, professional, disappointed, insulted

**Stakeholder-Specific Contract Terms:**
- `DriverContractTerms` - salary, duration, signing bonus, performance bonus, release clause, driver status
- `StaffContractTerms` - salary, duration, signing bonus, buyout, bonus percent
- `SponsorContractTerms` - annual payment, duration, placement, bonuses, exit clause
- `EngineContractTerms` - type alias for existing `ContractTerms` (DRY)

**Negotiation State:**
- `NegotiationRound<T>` - generic round tracking with typed terms
- `BaseNegotiation<T>` - common negotiation fields (id, phase, rounds, relationship tracking)
- `DriverNegotiation`, `StaffNegotiation`, `SponsorNegotiation`, `ManufacturerNegotiation` - typed extensions
- `Negotiation` - discriminated union of all types

**Backwards Compatibility:**
- Existing engine negotiation types (`NegotiationStatus`, `ContractTerms`, `ContractOffer`, `EngineNegotiation`) are preserved and marked as legacy
- Will be migrated to generic system in future PRs

~260 lines added to `src/shared/domain/types.ts`

## Test Plan
- [x] `yarn lint` passes
- [x] Types compile correctly
- [ ] Future PRs will use these types for the negotiation engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)