### PR TITLE
cleanup: remove unused Engine, Tyre, Fuel interfaces and Car.engineId

### DIFF
--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -503,7 +503,6 @@ function createInitialCars(teams: Team[]): Car[] {
         id: `${team.id}-car-${i}`,
         teamId: team.id,
         chassisId: `${team.id}-chassis-s1`, // Season 1 chassis placeholder
-        engineId: team.initialEngineManufacturerId,
         condition: INITIAL_CAR_CONDITION,
         mileage: 0,
         isRaceCar: true,

--- a/src/shared/domain/README.md
+++ b/src/shared/domain/README.md
@@ -125,42 +125,6 @@ Department head with significant impact on team performance.
 
 ## Technical Types
 
-### Engine
-Engine specification supplied by engine manufacturer.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Spec ID, e.g. `"phoenix-v10-01a"` |
-| `manufacturerId` | string | Engine manufacturer ID |
-| `name` | string | Display name |
-| `fuelEfficiency` | number | 0-100, lower fuel consumption |
-| `power` | number | 0-100, straight-line speed |
-| `reliability` | number | 0-100, resistance to failure |
-| `lightness` | number | 0-100, lighter = better performance |
-
-### Tyre
-Tyre specification by compound.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Unique ID |
-| `manufacturerId` | string | Tyre manufacturer ID |
-| `compound` | TyreCompound | Type of tyre |
-| `grip` | number | 0-100, road holding |
-| `durability` | number | 0-100, resistance to wear |
-| `temperatureRange` | number | 0-100, optimal operating range width |
-
-### Fuel
-Fuel specification.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string | Unique ID |
-| `manufacturerId` | string | Fuel manufacturer ID |
-| `name` | string | Display name |
-| `performance` | number | 0-100, combustion efficiency |
-| `engineTolerance` | number | 0-100, compatibility across engine types |
-
 ### Car
 A physical racing car owned by a team.
 
@@ -169,7 +133,6 @@ A physical racing car owned by a team.
 | `id` | string | Unique ID |
 | `teamId` | string | Owning team |
 | `chassisId` | string | Reference to chassis design |
-| `engineId` | string | Fitted engine spec |
 | `condition` | number | 0-100, degrades with use/damage |
 | `mileage` | number | Total miles driven |
 | `isRaceCar` | boolean | `true` = race car, `false` = R&D car |

--- a/src/shared/domain/types.ts
+++ b/src/shared/domain/types.ts
@@ -440,49 +440,12 @@ export interface Manufacturer {
 }
 
 /**
- * Engine specification - supplied by engine manufacturer
- */
-export interface Engine {
-  id: string; // e.g. "phoenix-v10-01a"
-  manufacturerId: string;
-  name: string;
-  fuelEfficiency: number; // 0-100, lower fuel consumption
-  power: number; // 0-100, straight-line speed
-  reliability: number; // 0-100, resistance to failure
-  lightness: number; // 0-100, lighter engines improve performance
-}
-
-/**
- * Tyre specification - supplied by tyre manufacturer
- */
-export interface Tyre {
-  id: string;
-  manufacturerId: string;
-  compound: TyreCompound;
-  grip: number; // 0-100
-  durability: number; // 0-100, resistance to wear
-  temperatureRange: number; // 0-100, optimal operating range width
-}
-
-/**
- * Fuel specification - supplied by fuel manufacturer
- */
-export interface Fuel {
-  id: string;
-  manufacturerId: string;
-  name: string;
-  performance: number; // 0-100, combustion efficiency
-  engineTolerance: number; // 0-100, compatibility across engine types
-}
-
-/**
  * Car - A physical racing car owned by a team
  */
 export interface Car {
   id: string;
   teamId: string;
   chassisId: string; // reference to chassis design
-  engineId: string;
   condition: number; // 0-100, degrades with use/damage
   mileage: number; // total miles driven
   isRaceCar: boolean; // false = R&D car


### PR DESCRIPTION
## Summary
- Removed unused `Engine`, `Tyre`, `Fuel` interfaces from `types.ts` (never imported anywhere)
- Removed `Car.engineId` property (set but never read; engine tracking now uses `TeamEngineState`)
- Updated `README.md` to reflect these removals

The new engine system uses `ActiveManufacturerContract` for manufacturer relationships and `TeamEngineState.car1Engine`/`car2Engine` for per-car spec tracking, making these interfaces obsolete.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)