### PR TITLE
feat: add INegotiationEngine interface and stub

### DIFF
--- a/src/main/engines/engine-manager.ts
+++ b/src/main/engines/engine-manager.ts
@@ -19,6 +19,7 @@ import type {
   IDriverPerformanceEngine,
   IRegulationEngine,
   ITurnEngine,
+  INegotiationEngine,
 } from '../../shared/domain/engines';
 
 import {
@@ -34,6 +35,7 @@ import {
   StubDriverPerformanceEngine,
   StubRegulationEngine,
   StubTurnEngine,
+  StubNegotiationEngine,
 } from './stubs';
 
 export class EngineManager {
@@ -49,4 +51,5 @@ export class EngineManager {
   driverPerformance: IDriverPerformanceEngine = new StubDriverPerformanceEngine();
   regulation: IRegulationEngine = new StubRegulationEngine();
   turn: ITurnEngine = new StubTurnEngine();
+  negotiation: INegotiationEngine = new StubNegotiationEngine();
 }

--- a/src/main/engines/index.ts
+++ b/src/main/engines/index.ts
@@ -20,4 +20,5 @@ export {
   StubDriverPerformanceEngine,
   StubRegulationEngine,
   StubTurnEngine,
+  StubNegotiationEngine,
 } from './stubs';

--- a/src/main/engines/stubs.ts
+++ b/src/main/engines/stubs.ts
@@ -19,6 +19,7 @@ import type {
   IDriverPerformanceEngine,
   IRegulationEngine,
   ITurnEngine,
+  INegotiationEngine,
   QualifyingInput,
   QualifyingResult,
   RaceInput,
@@ -60,6 +61,10 @@ import type {
   DesignCompletion,
   DesignUpdate,
   TestingUpdate,
+  NegotiationEvaluationInput,
+  NegotiationEvaluationResult,
+  NegotiationProcessingInput,
+  NegotiationProcessingResult,
 } from '../../shared/domain/engines';
 
 import type {
@@ -86,6 +91,8 @@ import {
   ConstructorStanding,
   hasRaceSeat,
   ChiefRole,
+  ResponseType,
+  ResponseTone,
 } from '../../shared/domain';
 import {
   getWeekNumber,
@@ -1516,6 +1523,43 @@ export class StubTurnEngine implements ITurnEngine {
       retiredChiefIds: determineChiefRetirements(chiefs),
       newCalendar: generateNewCalendar(circuits),
       resetDriverStates: generateResetDriverStates(drivers),
+    };
+  }
+}
+
+// =============================================================================
+// STUB NEGOTIATION ENGINE
+// =============================================================================
+
+/**
+ * StubNegotiationEngine - Placeholder implementation
+ *
+ * For MVP, this accepts all offers immediately.
+ * Will be replaced with full negotiation logic in later PRs.
+ */
+export class StubNegotiationEngine implements INegotiationEngine {
+  /**
+   * Evaluate a single offer - stub always accepts
+   */
+  evaluateOffer(_input: NegotiationEvaluationInput): NegotiationEvaluationResult {
+    // Stub: Accept immediately with professional tone, 2-day delay
+    return {
+      responseType: ResponseType.Accept,
+      counterTerms: null,
+      responseTone: ResponseTone.Professional,
+      responseDelayDays: 2,
+      isNewsworthy: false,
+      relationshipChange: 0,
+    };
+  }
+
+  /**
+   * Process all negotiations for a day - stub returns no updates
+   */
+  processDay(_input: NegotiationProcessingInput): NegotiationProcessingResult {
+    // Stub: No updates - negotiations will be processed by legacy system until migration
+    return {
+      updates: [],
     };
   }
 }


### PR DESCRIPTION
## Summary

Adds the `INegotiationEngine` interface and stub implementation for the generic negotiation system.

**New Types (in engines.ts):**
- `NegotiationEvaluationInput` - Input for evaluating a single offer
- `NegotiationEvaluationResult` - Response type, counter terms, tone, delay
- `NegotiationProcessingInput` - Input for daily processing of all negotiations
- `NegotiationUpdate` - Update to a single negotiation
- `NegotiationProcessingResult` - Result of daily processing

**Interface:**
- `INegotiationEngine.evaluateOffer()` - Evaluate an offer and generate response
- `INegotiationEngine.processDay()` - Process all negotiations for a day

**Stub Implementation:**
- `StubNegotiationEngine` - Placeholder that accepts all offers immediately
- Added to `EngineManager` and exports

~80 lines across 4 files.

## Test Plan
- [x] `yarn lint` passes
- [ ] Verify types compile correctly
- [ ] Future PRs will implement evaluator logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)