### PR TITLE
fix: set ResponseReceived phase when counterparty counters

### DIFF
--- a/src/main/engines/negotiation-engine.ts
+++ b/src/main/engines/negotiation-engine.ts
@@ -178,7 +178,10 @@ function determineNewPhase(responseType: ResponseType): NegotiationPhase {
     case ResponseType.Reject:
       return NegotiationPhase.Failed;
     case ResponseType.Counter:
+      // Counterparty countered - player's turn to respond
+      return NegotiationPhase.ResponseReceived;
     case ResponseType.NeedTime:
+      // Counterparty needs more time - still waiting for their decision
       return NegotiationPhase.AwaitingResponse;
     default:
       return NegotiationPhase.AwaitingResponse;

--- a/src/renderer/content/Contracts.tsx
+++ b/src/renderer/content/Contracts.tsx
@@ -649,11 +649,8 @@ function ActiveNegotiationCard({
   const latestRound = negotiation.rounds[negotiation.rounds.length - 1];
   // Get terms from the latest round (either player's offer or counterparty's response)
   const latestTerms: ContractTerms | null = latestRound?.terms ?? null;
-  // @agent: Check offeredBy instead of phase===ResponseReceived due to #160
-  // The negotiation engine sets Counter responses to AwaitingResponse instead of ResponseReceived
-  const canRespond = latestRound?.offeredBy === 'counterparty' &&
-    negotiation.phase !== NegotiationPhase.Completed &&
-    negotiation.phase !== NegotiationPhase.Failed;
+  // Player can respond when counterparty has made an offer/counter
+  const canRespond = negotiation.phase === NegotiationPhase.ResponseReceived;
 
   return (
     <div className="card p-4" style={ACCENT_CARD_STYLE}>


### PR DESCRIPTION
## Summary

Fixes #160

When the counterparty responds with a counter-offer, the negotiation phase should be `ResponseReceived` (player's turn to respond), not `AwaitingResponse`.

**Changes:**
- Update `determineNewPhase()` in negotiation engine to return `ResponseReceived` for `Counter` responses
- Simplify `canRespond` check in Contracts.tsx to use semantic phase check instead of workaround

**Before:** Counter → AwaitingResponse (incorrect - implies we're still waiting for counterparty)
**After:** Counter → ResponseReceived (correct - counterparty responded, player can act)

Note: `NeedTime` still returns `AwaitingResponse` since the counterparty hasn't made a decision yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)