### PR TITLE
refactor: add shared format utils for role labels and getFullName

### DIFF
--- a/src/main/services/contract-creator.ts
+++ b/src/main/services/contract-creator.ts
@@ -31,6 +31,7 @@ import {
   EntityType,
 } from '../../shared/domain';
 import { NegotiationPhase } from '../../shared/domain/types';
+import { getFullName } from '../../shared/utils/format';
 
 /** Initial bonus level for new contracts (0 = no bonus) */
 const INITIAL_BONUS_LEVEL = 0;
@@ -243,7 +244,7 @@ export function generateDriverSigningEvent(
 
   if (!driver || !newTeam) return;
 
-  const driverName = `${driver.firstName} ${driver.lastName}`;
+  const driverName = getFullName(driver);
   const isSwitching = oldTeam && oldTeam.id !== newTeam.id;
   const isRenewal = oldTeam && oldTeam.id === newTeam.id;
 
@@ -369,7 +370,7 @@ export function generateStaffSigningEvent(
 
   if (!chief || !newTeam) return;
 
-  const chiefName = `${chief.firstName} ${chief.lastName}`;
+  const chiefName = getFullName(chief);
   const roleName = getChiefRoleDisplayName(result.role);
   const isPoaching = oldTeam && oldTeam.id !== newTeam.id;
   const isRenewal = oldTeam && oldTeam.id === newTeam.id;

--- a/src/main/services/design-processor.ts
+++ b/src/main/services/design-processor.ts
@@ -40,6 +40,7 @@ import {
   type PendingPart,
 } from '../../shared/domain/types';
 import { offsetDate } from '../../shared/utils/date-utils';
+import { getFullName } from '../../shared/utils/format';
 
 /** Days to build a part after design completes */
 const PART_BUILD_TIME_DAYS = 7;
@@ -87,7 +88,7 @@ export function createDesignEmail(
  */
 export function formatChiefSender(chief: Chief | null): string {
   if (!chief) return 'Design Department';
-  return `${chief.firstName} ${chief.lastName} (Chief Designer)`;
+  return `${getFullName(chief)} (Chief Designer)`;
 }
 
 /**

--- a/src/main/services/negotiation-processor.ts
+++ b/src/main/services/negotiation-processor.ts
@@ -53,6 +53,7 @@ import {
   offsetDate,
   daysBetween,
 } from '../../shared/utils/date-utils';
+import { getFullName } from '../../shared/utils/format';
 import {
   generateBaseContractTerms,
   generateDefaultDriverTerms,
@@ -171,7 +172,7 @@ export function applyNegotiationUpdates(state: GameState, updates: NegotiationUp
 
           const driver = state.drivers.find((d) => d.id === driverNeg.driverId);
           if (driver) {
-            const driverName = `${driver.firstName} ${driver.lastName}`;
+            const driverName = getFullName(driver);
             const latestRound = driverNeg.rounds[driverNeg.rounds.length - 1];
             generateNegotiationUpdateEmail(
               state,
@@ -263,7 +264,7 @@ export function applyNegotiationUpdates(state: GameState, updates: NegotiationUp
           // Generate email for player
           const chief = state.chiefs.find((c) => c.id === staffNeg.staffId);
           if (chief) {
-            const chiefName = `${chief.firstName} ${chief.lastName}`;
+            const chiefName = getFullName(chief);
             const latestRound = staffNeg.rounds[staffNeg.rounds.length - 1];
             generateNegotiationUpdateEmail(
               state,
@@ -589,12 +590,13 @@ export function processDriverOutreach(state: GameState): boolean {
                 ? 'has noticed you may have a seat available'
                 : 'is exploring their options for next season';
 
+          const driverFullName = getFullName(driver);
           state.calendarEvents.push({
             id: randomUUID(),
             date: currentDate,
             type: CalendarEventType.Email,
-            subject: `${driver.firstName} ${driver.lastName} expresses interest in joining`,
-            body: `${driver.firstName} ${driver.lastName} has reached out to your team. The driver ${reasonText} and would like to discuss a contract for the ${seasonToYear(nextSeason)} season.`,
+            subject: `${driverFullName} expresses interest in joining`,
+            body: `${driverFullName} has reached out to your team. The driver ${reasonText} and would like to discuss a contract for the ${seasonToYear(nextSeason)} season.`,
             critical: true,
           });
         }
@@ -677,7 +679,7 @@ export function processStaffOutreach(state: GameState): boolean {
 
       // Create outreach negotiation
       const roleName = getChiefRoleDisplayName(chief.role);
-      const chiefName = `${chief.firstName} ${chief.lastName}`;
+      const chiefName = getFullName(chief);
 
       const negotiation: StaffNegotiation = {
         id: `neg-staff-${chief.id}-${targetTeam.id}-${Date.now()}`,

--- a/src/main/services/news-generator.ts
+++ b/src/main/services/news-generator.ts
@@ -32,10 +32,10 @@ import {
   NewsSource,
   NewsCategory,
   GamePhase,
-  ChiefRole,
 } from '../../shared/domain';
 import type { EventImportance } from '../../shared/domain/types';
 import { daysBetween } from '../../shared/utils/date-utils';
+import { getFullName, CHIEF_ROLE_LABELS } from '../../shared/utils/format';
 
 // =============================================================================
 // TYPES
@@ -157,7 +157,7 @@ export function createNamedQuote(
 ): NewsQuote {
   return {
     text,
-    attribution: `${person.firstName} ${person.lastName}`,
+    attribution: getFullName(person),
     attributionRole: role,
     isNamed: true,
   };
@@ -187,24 +187,8 @@ export function createPrincipalQuote(text: string, team: Team): NewsQuote {
  * Create a quote from a department chief
  */
 export function createChiefQuote(text: string, chief: Chief, team: Team): NewsQuote {
-  const roleTitle = getChiefRoleTitle(chief.role);
+  const roleTitle = CHIEF_ROLE_LABELS[chief.role];
   return createNamedQuote(text, chief, `${team.shortName} ${roleTitle}`);
-}
-
-/**
- * Get display title for a chief role
- */
-function getChiefRoleTitle(role: ChiefRole): string {
-  switch (role) {
-    case ChiefRole.Designer:
-      return 'Chief Designer';
-    case ChiefRole.Mechanic:
-      return 'Chief Mechanic';
-    case ChiefRole.Commercial:
-      return 'Commercial Manager';
-    default:
-      return 'Chief';
-  }
 }
 
 /**
@@ -462,7 +446,7 @@ function pickRacePreviewContent(
   gap: number
 ): { subject: string; body: string } {
   const circuitType = getCircuitType(circuit);
-  const leaderName = leader ? `${leader.firstName} ${leader.lastName}` : 'The championship leader';
+  const leaderName = leader ? getFullName(leader) : 'The championship leader';
 
   const subjects = [
     `${circuit.name} Preview: All eyes on the ${circuit.country} GP`,
@@ -505,9 +489,9 @@ function pickRacePredictionsContent(
 
   const [d1, d2, d3] = topDrivers;
   const body = `As we approach race day at ${circuit.name}, here are our predictions for the weekend.\n\n` +
-    `**Race Winner:** ${d1.firstName} ${d1.lastName} - Current form and championship momentum make them the favorite.\n\n` +
-    `**Podium Contender:** ${d2.firstName} ${d2.lastName} - Has shown strong pace and will be pushing hard.\n\n` +
-    `**Dark Horse:** ${d3.firstName} ${d3.lastName} - Could spring a surprise if conditions play into their hands.`;
+    `**Race Winner:** ${getFullName(d1)} - Current form and championship momentum make them the favorite.\n\n` +
+    `**Podium Contender:** ${getFullName(d2)} - Has shown strong pace and will be pushing hard.\n\n` +
+    `**Dark Horse:** ${getFullName(d3)} - Could spring a surprise if conditions play into their hands.`;
 
   return {
     subject: pickRandom(subjects),

--- a/src/main/services/race-processor.ts
+++ b/src/main/services/race-processor.ts
@@ -43,6 +43,7 @@ import {
   generateEstimatedPower,
 } from '../../shared/domain/engine-utils';
 import { getWeekNumber } from '../../shared/utils/date-utils';
+import { getFullName } from '../../shared/utils/format';
 
 /** Post-Race Repair Costs - values per proposal.md, simplified for MVP */
 const REPAIR_COST_BASE = 50000; // Routine maintenance after every race
@@ -208,7 +209,7 @@ function calculateCarRepairCost(
   return {
     carNumber,
     driverId: driver.id,
-    driverName: `${driver.firstName} ${driver.lastName}`,
+    driverName: getFullName(driver),
     baseCost: REPAIR_COST_BASE,
     incidentCost,
     totalCost: REPAIR_COST_BASE + incidentCost,

--- a/src/main/services/turn-processor.ts
+++ b/src/main/services/turn-processor.ts
@@ -40,6 +40,7 @@ import {
   CalendarEventType,
 } from '../../shared/domain';
 import { isSameDay } from '../../shared/utils/date-utils';
+import { getFullName } from '../../shared/utils/format';
 import {
   type PartReadyData,
   type SpecReleaseData,
@@ -157,15 +158,15 @@ export function checkPendingParts(state: GameState, currentDate: GameDate): bool
       baseCost: pendingPart.baseCost,
       recommendedCar,
       recommendedDriverId: recommendedDriver.id,
-      recommendedDriverName: `${recommendedDriver.firstName} ${recommendedDriver.lastName}`,
+      recommendedDriverName: getFullName(recommendedDriver),
       otherDriverId: otherDriver.id,
-      otherDriverName: `${otherDriver.firstName} ${otherDriver.lastName}`,
+      otherDriverName: getFullName(otherDriver),
       chiefId: chiefDesigner?.id,
     };
 
     const subject = `Part ready: ${pendingPart.item}`;
     const body = `The ${pendingPart.item} is now ready for installation. ` +
-      `We recommend installing on ${recommendedDriver.firstName} ${recommendedDriver.lastName}'s car first. ` +
+      `We recommend installing on ${getFullName(recommendedDriver)}'s car first. ` +
       `Installation cost: $${pendingPart.baseCost.toLocaleString()} per car, ` +
       `or $${(pendingPart.baseCost * 3).toLocaleString()} for both cars (rush).`;
 

--- a/src/renderer/components/AppointmentNewsModal.tsx
+++ b/src/renderer/components/AppointmentNewsModal.tsx
@@ -7,7 +7,7 @@
 
 import { Newspaper, ArrowRight } from 'lucide-react';
 import type { AppointmentNews, AppointmentDriverSummary } from '../../shared/domain';
-import { formatCurrency } from '../utils/format';
+import { formatCurrency, getFullName } from '../utils/format';
 import { seasonToYear, yearToSeason } from '../../shared/utils/date-utils';
 import { PRIMARY_BUTTON_CLASSES } from '../utils/theme-styles';
 
@@ -40,7 +40,7 @@ function DriverCard({ driver, seasonNumber, lastSeasonYear }: DriverCardProps) {
         {driver.photoUrl ? (
           <img
             src={driver.photoUrl}
-            alt={`${driver.firstName} ${driver.lastName}`}
+            alt={getFullName(driver)}
             className="w-full h-full object-cover object-top"
           />
         ) : (
@@ -57,7 +57,7 @@ function DriverCard({ driver, seasonNumber, lastSeasonYear }: DriverCardProps) {
             <span className="text-xs font-bold text-muted">#{driver.raceNumber}</span>
           )}
           <span className="font-semibold text-primary truncate">
-            {driver.firstName} {driver.lastName}
+            {getFullName(driver)}
           </span>
         </div>
 

--- a/src/renderer/components/DriverProfileContent.tsx
+++ b/src/renderer/components/DriverProfileContent.tsx
@@ -20,6 +20,7 @@ import {
   isHistoricalRetiredStatus,
   getHistoricalPositionStyle,
   getChampionshipPositionStyle,
+  getFullName,
 } from '../utils/format';
 import { seasonToYear, calculateAge } from '../../shared/utils/date-utils';
 import {
@@ -452,12 +453,12 @@ export function DriverProfileContent({
   allTeams,
 }: DriverProfileContentProps) {
   const age = calculateAge(driver.dateOfBirth, seasonToYear(currentSeason));
-  const fullName = `${driver.firstName} ${driver.lastName}`;
+  const fullName = getFullName(driver);
 
   // Build dropdown options if provided
   const dropdownOptions = allDrivers?.map((driverOption) => ({
     id: driverOption.id,
-    label: `${driverOption.firstName} ${driverOption.lastName}`,
+    label: getFullName(driverOption),
   }));
 
   return (

--- a/src/renderer/components/TeamProfileCards.tsx
+++ b/src/renderer/components/TeamProfileCards.tsx
@@ -14,6 +14,7 @@ import {
   formatContractLine,
   DRIVER_ROLE_LABELS,
   CHIEF_ROLE_LABELS,
+  getFullName,
 } from '../utils/format';
 import type { Team, Driver, Chief, DriverStanding, ConstructorStanding } from '../../shared/domain';
 
@@ -93,7 +94,7 @@ export function DriverCard({ driver, standing }: DriverCardProps) {
         {driver.photoUrl ? (
           <img
             src={driver.photoUrl}
-            alt={`${driver.firstName} ${driver.lastName}`}
+            alt={getFullName(driver)}
             className="w-full h-full object-cover"
           />
         ) : (
@@ -103,7 +104,7 @@ export function DriverCard({ driver, standing }: DriverCardProps) {
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
           <EntityLink type="driver" id={driver.id} className="font-bold">
-            {driver.firstName} {driver.lastName}
+            {getFullName(driver)}
           </EntityLink>
           <FlagIcon country={driver.nationality} size="sm" />
         </div>
@@ -134,7 +135,7 @@ export function ChiefCard({ chief }: ChiefCardProps) {
         {CHIEF_ROLE_LABELS[chief.role] ?? chief.role}
       </div>
       <EntityLink type="chief" id={chief.id} className="font-bold block">
-        {chief.firstName} {chief.lastName}
+        {getFullName(chief)}
       </EntityLink>
       <div className="text-xs text-muted mt-2 space-y-0.5">
         <div>Ability: {chief.ability}</div>

--- a/src/renderer/content/Championship.tsx
+++ b/src/renderer/content/Championship.tsx
@@ -7,6 +7,7 @@ import {
   TABLE_BODY_CLASS,
   getHighlightedRowStyles,
 } from '../utils/theme-styles';
+import { getFullName } from '../utils/format';
 import type {
   DriverStanding,
   ConstructorStanding,
@@ -71,7 +72,7 @@ interface DriverRowProps {
 function DriverRow({ standing, driver, team, isPlayerTeam, onDriverClick }: DriverRowProps) {
   const styles = getHighlightedRowStyles(isPlayerTeam);
   const driverName = driver
-    ? `${driver.firstName} ${driver.lastName}`
+    ? getFullName(driver)
     : standing.driverId;
 
   return (

--- a/src/renderer/content/Construction.tsx
+++ b/src/renderer/content/Construction.tsx
@@ -4,7 +4,7 @@ import { SectionHeading, Dropdown, EntityLink } from '../components';
 import type { DropdownOption } from '../components';
 import { ACCENT_CARD_STYLE } from '../utils/theme-styles';
 import { formatGameDate, seasonToYear } from '../../shared/utils/date-utils';
-import { formatCurrency } from '../utils/format';
+import { formatCurrency, getFullName } from '../utils/format';
 import { PartsLogEntryType, type PartsLogEntry, type Driver } from '../../shared/domain';
 
 // ===========================================
@@ -42,7 +42,7 @@ function buildSeasonOptions(
 /** Get driver display name from ID */
 function getDriverName(driverId: string, drivers: Driver[]): string {
   const driver = drivers.find((d) => d.id === driverId);
-  return driver ? `${driver.firstName} ${driver.lastName}` : 'Unknown Driver';
+  return driver ? getFullName(driver) : 'Unknown Driver';
 }
 
 /** Format details column based on entry type */

--- a/src/renderer/content/Contracts.tsx
+++ b/src/renderer/content/Contracts.tsx
@@ -3,7 +3,7 @@ import { useDerivedGameState } from '../hooks';
 import { SectionHeading, TabBar } from '../components';
 import type { Tab } from '../components';
 import { ACCENT_CARD_STYLE, GHOST_BORDERED_BUTTON_CLASSES, PRIMARY_BUTTON_CLASSES } from '../utils/theme-styles';
-import { formatCurrency } from '../utils/format';
+import { formatCurrency, getFullName } from '../utils/format';
 import { seasonToYear } from '../../shared/utils/date-utils';
 import { IpcChannels } from '../../shared/ipc';
 import {
@@ -168,7 +168,7 @@ function CarEngineCard({
   );
 
   const isLatestSpec = carEngine.specVersion >= latestSpec;
-  const driverName = driver ? `${driver.firstName} ${driver.lastName}` : `Car ${carNumber}`;
+  const driverName = driver ? getFullName(driver) : `Car ${carNumber}`;
 
   return (
     <div className="card p-4" style={ACCENT_CARD_STYLE}>

--- a/src/renderer/content/Finance.tsx
+++ b/src/renderer/content/Finance.tsx
@@ -1,6 +1,6 @@
 import { useDerivedGameState } from '../hooks';
 import { SectionHeading } from '../components';
-import { formatCurrency } from '../utils/format';
+import { formatCurrency, getFullName } from '../utils/format';
 import { ACCENT_CARD_STYLE, ACCENT_TEXT_STYLE } from '../utils/theme-styles';
 import type {
   ActiveSponsorDeal,
@@ -168,7 +168,7 @@ function ExpensesSection({
             {drivers.map((driver) => (
               <LineItem
                 key={driver.id}
-                label={`${driver.firstName} ${driver.lastName}`}
+                label={getFullName(driver)}
                 amount={driver.salary}
                 isExpense
               />
@@ -181,7 +181,7 @@ function ExpensesSection({
             {chiefs.map((chief) => (
               <LineItem
                 key={chief.id}
-                label={`${chief.firstName} ${chief.lastName}`}
+                label={getFullName(chief)}
                 sublabel={chief.role}
                 amount={chief.salary}
                 isExpense

--- a/src/renderer/content/Mail.tsx
+++ b/src/renderer/content/Mail.tsx
@@ -17,6 +17,7 @@ import type {
 import type { DropdownOption } from '../components/Dropdown';
 import { getFilteredCalendarEvents } from '../utils/calendar-event-utils';
 import { formatGameDate, formatDateGroupHeader, dateKey } from '../../shared/utils/date-utils';
+import { getFullName } from '../utils/format';
 import { generateFace, FREE_AGENT_COLORS } from '../utils/face-generator';
 import { ACCENT_BORDERED_BUTTON_STYLE } from '../utils/theme-styles';
 
@@ -352,7 +353,7 @@ function ChiefDesignerLink({ chief }: { chief: Chief | null }) {
     <div className="text-sm text-secondary">
       Chief Designer:{' '}
       <EntityLink type="chief" id={chief.id}>
-        {chief.firstName} {chief.lastName}
+        {getFullName(chief)}
       </EntityLink>
     </div>
   );

--- a/src/renderer/content/Results.tsx
+++ b/src/renderer/content/Results.tsx
@@ -7,6 +7,7 @@ import {
   isHistoricalRetiredStatus,
   getHistoricalPositionStyle,
   getMedalPositionStyle,
+  getFullName,
 } from '../utils/format';
 import {
   TABLE_CELL_BASE,
@@ -107,7 +108,7 @@ function createEntityLookups(
 }
 
 function formatDriverName(driver: Driver | undefined, fallbackId: string): string {
-  return driver ? `${driver.firstName} ${driver.lastName}` : fallbackId;
+  return driver ? getFullName(driver) : fallbackId;
 }
 
 function sortRaceResults(results: DriverRaceResult[]): DriverRaceResult[] {
@@ -542,7 +543,7 @@ function SeasonGrid({
                       onClick={() => onDriverClick(driverId)}
                       className="hover:underline font-semibold text-left text-primary cursor-pointer"
                     >
-                      {driver.firstName} {driver.lastName}
+                      {getFullName(driver)}
                     </button>
                   </td>
                   <td className="w-28 px-2 py-2 text-secondary text-sm whitespace-nowrap">

--- a/src/renderer/content/Staff.tsx
+++ b/src/renderer/content/Staff.tsx
@@ -9,6 +9,7 @@ import {
   STAFF_QUALITY_ORDER,
   CHIEF_ROLE_ORDER,
   ROLE_TO_DEPARTMENT,
+  getFullName,
 } from '../utils/format';
 import { ACCENT_CARD_STYLE } from '../utils/theme-styles';
 import {
@@ -56,7 +57,7 @@ function ChiefCard({ chief, departmentMorale }: ChiefCardProps) {
             {CHIEF_ROLE_LABELS[chief.role]}
           </div>
           <div className="text-lg font-semibold text-primary">
-            {chief.firstName} {chief.lastName}
+            {getFullName(chief)}
           </div>
         </div>
         <div className="text-right">

--- a/src/renderer/content/Testing.tsx
+++ b/src/renderer/content/Testing.tsx
@@ -10,6 +10,7 @@ import {
   estimateTestCompletionDays,
   MAX_TEST_PROGRESS,
 } from '../../shared/domain/testing-utils';
+import { getFullName } from '../utils/format';
 
 // ===========================================
 // TYPES
@@ -135,7 +136,7 @@ function SetupState({
   onCancel,
 }: SetupStateProps) {
   const driverOptions: DropdownOption<string>[] = useMemo(
-    () => drivers.map((d) => ({ value: d.id, label: `${d.firstName} ${d.lastName}` })),
+    () => drivers.map((d) => ({ value: d.id, label: getFullName(d) })),
     [drivers]
   );
 
@@ -525,7 +526,7 @@ export function Testing() {
   const testDriverName = useMemo(() => {
     if (!testSession.driverId) return 'Unknown';
     const driver = teamDrivers.find((d) => d.id === testSession.driverId);
-    return driver ? `${driver.firstName} ${driver.lastName}` : 'Unknown';
+    return driver ? getFullName(driver) : 'Unknown';
   }, [testSession.driverId, teamDrivers]);
 
   // Find latest discovered problem (for results view)

--- a/src/renderer/content/world/WorldStaff.tsx
+++ b/src/renderer/content/world/WorldStaff.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../components';
 import { ChiefRole, type Chief, type Team, type TeamPrincipal } from '../../../shared/domain';
 import { FREE_AGENT_COLORS } from '../../utils/face-generator';
+import { getFullName } from '../../utils/format';
 
 // ===========================================
 // TYPES
@@ -144,7 +145,7 @@ export function WorldStaff({ initialStaffId }: WorldStaffProps) {
   // Build dropdown options
   const dropdownOptions = filteredStaff.map((s) => ({
     id: s.id,
-    label: `${s.firstName} ${s.lastName}`,
+    label: getFullName(s),
   }));
 
   // Get team info for selected staff
@@ -176,7 +177,7 @@ export function WorldStaff({ initialStaffId }: WorldStaffProps) {
         <div className="space-y-6">
           {/* Header with dropdown */}
           <PersonHeader
-            name={`${selectedStaff.firstName} ${selectedStaff.lastName}`}
+            name={getFullName(selectedStaff)}
             nationality={selectedStaff.nationality ?? 'UN'}
             photoUrl={null}
             teamName={staffTeam?.name ?? null}

--- a/src/renderer/hooks/useGlobalSearch.ts
+++ b/src/renderer/hooks/useGlobalSearch.ts
@@ -7,6 +7,7 @@ import { useMemo, useState, useCallback } from 'react';
 import { useDerivedGameState } from './useDerivedGameState';
 import { sections } from '../navigation';
 import type { EntityType } from '../utils/entity-navigation';
+import { getFullName } from '../utils/format';
 
 // ===========================================
 // TYPES
@@ -105,7 +106,7 @@ export function useGlobalSearch() {
         items.push({
           id: driver.id,
           type: 'driver',
-          label: `${driver.firstName} ${driver.lastName}`,
+          label: getFullName(driver),
           sublabel: team?.name ?? 'Free Agent',
         });
       }
@@ -118,7 +119,7 @@ export function useGlobalSearch() {
         items.push({
           id: chief.id,
           type: 'chief',
-          label: `${chief.firstName} ${chief.lastName}`,
+          label: getFullName(chief),
           sublabel: `${chief.role.charAt(0).toUpperCase() + chief.role.slice(1)}${team ? ` • ${team.name}` : ' • Free Agent'}`,
         });
       }

--- a/src/renderer/screens/TeamSelectScreen.tsx
+++ b/src/renderer/screens/TeamSelectScreen.tsx
@@ -12,7 +12,7 @@ import { BackgroundLayer } from '../components';
 import { TeamBadge } from '../components/TeamBadge';
 import { IconButton } from '../components/NavButtons';
 import { PRIMARY_BUTTON_CLASSES, GHOST_BUTTON_CLASSES } from '../utils/theme-styles';
-import { formatCurrency, DRIVER_ROLE_LABELS } from '../utils/format';
+import { formatCurrency, DRIVER_ROLE_LABELS, getFullName } from '../utils/format';
 
 interface LocationState {
   playerName: string;
@@ -85,7 +85,7 @@ function DriverPhoto({ driver, teamColors }: DriverPhotoProps) {
     return (
       <img
         src={driver.photoUrl}
-        alt={`${driver.firstName} ${driver.lastName}`}
+        alt={getFullName(driver)}
         className="w-12 h-12 rounded-full object-cover"
         onError={() => setImageError(true)}
       />
@@ -332,7 +332,7 @@ export function TeamSelectScreen() {
                     <DriverPhoto driver={driver} teamColors={teamColors} />
                     <div className="flex-1 min-w-0">
                       <p className="text-primary font-medium truncate">
-                        {driver.firstName} {driver.lastName}
+                        {getFullName(driver)}
                       </p>
                       <p className="text-muted text-sm">{DRIVER_ROLE_LABELS[driver.role]}</p>
                     </div>

--- a/src/renderer/utils/format.ts
+++ b/src/renderer/utils/format.ts
@@ -1,46 +1,23 @@
 /**
- * Shared formatting utilities
+ * Renderer-specific formatting utilities
+ *
+ * Re-exports shared constants from src/shared/utils/format.ts
+ * and adds renderer-specific helpers
  */
 
-import {
-  type DriverRole,
-  Department,
-  StaffQuality,
-  ChiefRole,
-} from '../../shared/domain';
+import { Department, StaffQuality, ChiefRole } from '../../shared/domain';
 import { compareSavesByNewest, type SaveSlotInfo } from '../../shared/ipc';
 import { formatGameDate, seasonToYear } from '../../shared/utils/date-utils';
 
-// ===========================================
-// ROLE & LABEL CONSTANTS
-// ===========================================
-
-export const DRIVER_ROLE_LABELS: Record<DriverRole, string> = {
-  first: '1st Driver',
-  second: '2nd Driver',
-  equal: 'Driver',
-  test: 'Test Driver',
-};
-
-export const DEPARTMENT_LABELS: Record<Department, string> = {
-  [Department.Commercial]: 'Commercial',
-  [Department.Design]: 'Design',
-  [Department.Mechanics]: 'Mechanics',
-};
-
-export const CHIEF_ROLE_LABELS: Record<ChiefRole, string> = {
-  [ChiefRole.Commercial]: 'Commercial Manager',
-  [ChiefRole.Designer]: 'Chief Designer',
-  [ChiefRole.Mechanic]: 'Chief Mechanic',
-};
-
-export const STAFF_QUALITY_LABELS: Record<StaffQuality, string> = {
-  [StaffQuality.Excellent]: 'Excellent',
-  [StaffQuality.VeryGood]: 'Very Good',
-  [StaffQuality.Good]: 'Good',
-  [StaffQuality.Average]: 'Average',
-  [StaffQuality.Trainee]: 'Trainee',
-};
+// Re-export shared constants and helpers
+export {
+  DRIVER_ROLE_LABELS,
+  DEPARTMENT_LABELS,
+  CHIEF_ROLE_LABELS,
+  STAFF_QUALITY_LABELS,
+  getFullName,
+  type HasName,
+} from '../../shared/utils/format';
 
 // ===========================================
 // DISPLAY ORDER ARRAYS

--- a/src/shared/utils/format.ts
+++ b/src/shared/utils/format.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared formatting utilities used by both main and renderer processes
+ */
+
+import { ChiefRole, Department, DriverRole, StaffQuality } from '../domain';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Interface for any object with firstName and lastName properties
+ * Works with Driver, Chief, or any similar entity
+ */
+export interface HasName {
+  firstName: string;
+  lastName: string;
+}
+
+// =============================================================================
+// NAME FORMATTING
+// =============================================================================
+
+/**
+ * Get full name from any object with firstName and lastName
+ * Replaces the repeated `${person.firstName} ${person.lastName}` pattern
+ */
+export function getFullName(person: HasName): string {
+  return `${person.firstName} ${person.lastName}`;
+}
+
+// =============================================================================
+// ROLE & LABEL CONSTANTS
+// =============================================================================
+
+export const DRIVER_ROLE_LABELS: Record<DriverRole, string> = {
+  [DriverRole.First]: '1st Driver',
+  [DriverRole.Second]: '2nd Driver',
+  [DriverRole.Equal]: 'Driver',
+  [DriverRole.Test]: 'Test Driver',
+};
+
+export const DEPARTMENT_LABELS: Record<Department, string> = {
+  [Department.Commercial]: 'Commercial',
+  [Department.Design]: 'Design',
+  [Department.Mechanics]: 'Mechanics',
+};
+
+export const CHIEF_ROLE_LABELS: Record<ChiefRole, string> = {
+  [ChiefRole.Commercial]: 'Commercial Manager',
+  [ChiefRole.Designer]: 'Chief Designer',
+  [ChiefRole.Mechanic]: 'Chief Mechanic',
+};
+
+export const STAFF_QUALITY_LABELS: Record<StaffQuality, string> = {
+  [StaffQuality.Excellent]: 'Excellent',
+  [StaffQuality.VeryGood]: 'Very Good',
+  [StaffQuality.Good]: 'Good',
+  [StaffQuality.Average]: 'Average',
+  [StaffQuality.Trainee]: 'Trainee',
+};

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './date-utils';
+export * from './format';


### PR DESCRIPTION
## Summary
- Fixes #191: Move `CHIEF_ROLE_LABELS` to shared for DRY
- Fixes #194: Extract `getFullName` helper for Driver/Chief name formatting

## Changes
- Create `src/shared/utils/format.ts` with:
  - `DRIVER_ROLE_LABELS`, `CHIEF_ROLE_LABELS`, `DEPARTMENT_LABELS`, `STAFF_QUALITY_LABELS` constants
  - `getFullName(person)` helper function that replaces the repeated `${person.firstName} ${person.lastName}` pattern
  - `HasName` interface for type safety
- Update `src/shared/utils/index.ts` to export from new format file
- Update `src/renderer/utils/format.ts` to re-export shared constants
- Remove duplicate `getChiefRoleTitle()` function from `news-generator.ts`
- Replace ~35 occurrences of the firstName/lastName pattern across:
  - Main process: news-generator, design-processor, contract-creator, negotiation-processor, turn-processor, race-processor
  - Renderer: 14 component/content files

## Test plan
- [x] Lint passes
- [ ] Verify app starts and displays names correctly
- [ ] Verify news headlines show correct names
- [ ] Verify search shows correct names

🤖 Generated with [Claude Code](https://claude.com/claude-code)