### PR TITLE
feat: add pre-season and analysis news generators (PR 6 from news-plan)

### DIFF
--- a/src/main/services/news-generator.ts
+++ b/src/main/services/news-generator.ts
@@ -35,6 +35,7 @@ import {
   NewsCategory,
   NewsEventType,
   GamePhase,
+  DriverRole,
 } from '../../shared/domain';
 import type { EventImportance } from '../../shared/domain/types';
 import { daysBetween } from '../../shared/utils/date-utils';
@@ -857,7 +858,7 @@ function generateDriverRankings(context: NewsGenerationContext): CalendarEvent |
 
   // Get all race drivers sorted by rating
   const raceDrivers = state.drivers
-    .filter((d) => d.teamId && d.role !== 'test')
+    .filter((d) => d.teamId && d.role !== DriverRole.Test)
     .sort((a, b) => {
       const aRating = (a.stats.speed + a.stats.consistency + a.stats.racecraft) / 3;
       const bRating = (b.stats.speed + b.stats.consistency + b.stats.racecraft) / 3;


### PR DESCRIPTION
## Summary

Implements PR 6 from news-plan.md: Pre-Season & Analysis News.

**Pre-Season News (runs during PreSeason phase):**
- **Season Preview** - Generated on day 15 (mid-January), high importance
- **Driver Rankings** - Generated on day 30 (late January), top 5 drivers by rating

**Mid-Season Analysis (runs during racing season):**
- **Hot Seat Analysis** - Every 3 races, identifies drivers significantly behind teammates (20+ points gap)
- **Performance Analysis** - Every 5 races, compares teams against expected position based on prestige

All generators integrate with the existing `generateDailyNews()` flow and use the established NewsSource/NewsCategory system.

## Changes

- `src/main/services/news-generator.ts`:
  - Added `generatePreSeasonNews()` calling season preview and driver rankings
  - Added `generateAnalysisNews()` calling hot seat and performance analysis
  - Added 4 new generator functions with templates
  - Wired into `generateDailyNews()`

## Test plan

- [ ] Start new game, verify season preview appears ~Jan 15
- [ ] Verify driver rankings appears ~Jan 30
- [ ] Simulate to race 3, verify hot seat analysis appears if applicable
- [ ] Simulate to race 5, verify performance analysis appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)