### PR TITLE
fix: delay simulation overlay close to show final day animation

### DIFF
--- a/src/renderer/components/SimulationOverlay.tsx
+++ b/src/renderer/components/SimulationOverlay.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect, useRef } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { GameDate, CalendarEvent, CalendarEntry, Circuit, Team } from '../../shared/domain';
 import { TopBar } from './TopBar';
@@ -13,7 +13,7 @@ const CURRENT_DAY_INDEX = 1;
 const TOTAL_DAYS = 9;
 
 /** Delay before closing overlay after simulation stops (ms) - allows final day animation to complete */
-const POST_SIMULATION_DELAY_MS = 600;
+const POST_SIMULATION_DELAY_MS = 1500;
 
 /** Slide animation offset (1/9 of width as percentage) */
 const SLIDE_OFFSET_PERCENT = `${(100 / TOTAL_DAYS).toFixed(2)}%`;
@@ -43,23 +43,18 @@ export function SimulationOverlay({
   // Track delayed visibility - keeps overlay visible briefly after simulation stops
   // so the final day animation completes and events are visible
   const [delayedVisible, setDelayedVisible] = useState(isVisible);
-  const wasVisibleRef = useRef(isVisible);
 
   useEffect(() => {
-    // Simulation started - show immediately
-    if (isVisible && !wasVisibleRef.current) {
+    if (isVisible) {
+      // Simulation started - show immediately
       setDelayedVisible(true);
-    }
-
-    // Simulation stopped - delay before hiding
-    if (!isVisible && wasVisibleRef.current) {
+    } else {
+      // Simulation stopped - delay before hiding
       const timer = setTimeout(() => {
         setDelayedVisible(false);
       }, POST_SIMULATION_DELAY_MS);
       return () => clearTimeout(timer);
     }
-
-    wasVisibleRef.current = isVisible;
   }, [isVisible]);
 
   const animationKey = dateKey(currentDate);


### PR DESCRIPTION
## Summary
- Adds a 1500ms delay before closing the simulation overlay when simulation stops
- This ensures the final day's slide animation completes and events that occurred on the final tick are visible to the user

## Problem
When simulation stopped (e.g., design breakthrough happens), the overlay would close immediately, causing:
1. The calendar animation to appear one day behind (e.g., shows 14 Jan when actual date is 15 Jan)
2. Events occurring on the final tick (like design breakthroughs) not being visible on the calendar

## Solution
Uses a `delayedVisible` state that:
- Shows the overlay immediately when simulation starts
- Delays 1500ms before hiding when simulation stops
- Allows the final slide animation (250ms) plus time for user to see the final state

## Test plan
- [ ] Start simulation and let it run
- [ ] Verify calendar animates smoothly day by day
- [ ] Wait for a design milestone/breakthrough to trigger auto-stop
- [ ] Verify the calendar shows the correct current day (not one day behind)
- [ ] Verify any events from the final day are visible before overlay closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)