### PR TITLE
feat: add quit game button to title screen

### DIFF
--- a/src/renderer/screens/TitleScreen.tsx
+++ b/src/renderer/screens/TitleScreen.tsx
@@ -1,14 +1,15 @@
 import { useNavigate } from 'react-router-dom';
-import { Play, Plus, FolderOpen, Loader2 } from 'lucide-react';
+import { Play, Plus, FolderOpen, Loader2, Power } from 'lucide-react';
 import { RoutePaths } from '../routes';
-import { PRIMARY_BUTTON_CLASSES, GHOST_BUTTON_CLASSES, ERROR_ALERT_CLASSES } from '../utils/theme-styles';
-import { useSavesList, useLoadGameHandler, TEAM_ID_ALL } from '../hooks';
+import { PRIMARY_BUTTON_CLASSES, GHOST_BUTTON_CLASSES, DANGER_BUTTON_CLASSES, ERROR_ALERT_CLASSES } from '../utils/theme-styles';
+import { useSavesList, useLoadGameHandler, useQuitApp, TEAM_ID_ALL } from '../hooks';
 import { BackgroundLayer } from '../components';
 
 export function TitleScreen() {
   const navigate = useNavigate();
   const { data: saves } = useSavesList();
   const { loadingFilename, loadError, handleLoad } = useLoadGameHandler();
+  const quitApp = useQuitApp();
 
   const hasSaves = saves && saves.length > 0;
   const mostRecentSave = hasSaves ? saves[0] : null;
@@ -80,6 +81,14 @@ export function TitleScreen() {
           >
             <Plus size={20} />
             <span>New Game</span>
+          </button>
+          <button
+            type="button"
+            onClick={quitApp}
+            className={`${DANGER_BUTTON_CLASSES} px-8 py-3 text-lg justify-center`}
+          >
+            <Power size={20} />
+            <span>Quit</span>
           </button>
         </div>
       </div>

--- a/src/renderer/screens/TitleScreen.tsx
+++ b/src/renderer/screens/TitleScreen.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Play, Plus, FolderOpen, Loader2, Power } from 'lucide-react';
 import { RoutePaths } from '../routes';
-import { PRIMARY_BUTTON_CLASSES, GHOST_BUTTON_CLASSES, DANGER_BUTTON_CLASSES, ERROR_ALERT_CLASSES } from '../utils/theme-styles';
+import { PRIMARY_BUTTON_CLASSES, NEUTRAL_BUTTON_CLASSES, DANGER_BUTTON_CLASSES, ERROR_ALERT_CLASSES } from '../utils/theme-styles';
 import { useSavesList, useLoadGameHandler, useQuitApp, TEAM_ID_ALL } from '../hooks';
 import { BackgroundLayer } from '../components';
 
@@ -67,7 +67,7 @@ export function TitleScreen() {
               <button
                 type="button"
                 onClick={() => navigate(RoutePaths.LOAD_GAME)}
-                className={`${GHOST_BUTTON_CLASSES} px-8 py-3 text-lg justify-center`}
+                className={`${NEUTRAL_BUTTON_CLASSES} px-8 py-3 text-lg justify-center`}
               >
                 <FolderOpen size={20} />
                 <span>Load Game</span>
@@ -77,7 +77,7 @@ export function TitleScreen() {
           <button
             type="button"
             onClick={() => navigate(RoutePaths.PLAYER_NAME)}
-            className={`${hasSaves ? GHOST_BUTTON_CLASSES : PRIMARY_BUTTON_CLASSES} px-8 py-3 text-lg justify-center`}
+            className={`${hasSaves ? NEUTRAL_BUTTON_CLASSES : PRIMARY_BUTTON_CLASSES} px-8 py-3 text-lg justify-center`}
           >
             <Plus size={20} />
             <span>New Game</span>

--- a/src/renderer/utils/theme-styles.ts
+++ b/src/renderer/utils/theme-styles.ts
@@ -95,6 +95,12 @@ export const GHOST_BORDERED_BUTTON_CLASSES =
   'cursor-pointer bg-[var(--neutral-800)] border-[var(--neutral-700)] text-secondary hover:bg-[var(--neutral-750)] hover:text-primary hover:border-[var(--neutral-600)]';
 
 /**
+ * Neutral button - secondary actions with background (Load Game, etc.)
+ */
+export const NEUTRAL_BUTTON_CLASSES =
+  'btn px-4 py-2 font-semibold bg-[var(--neutral-700)] text-primary border border-[var(--neutral-600)] rounded-lg cursor-pointer hover:bg-[var(--neutral-600)] transition-all duration-200 flex items-center gap-2';
+
+/**
  * Danger button - destructive actions (Delete confirmation, etc.)
  */
 export const DANGER_BUTTON_CLASSES =


### PR DESCRIPTION
## Summary
- Adds a "Quit" button to the title screen menu using `DANGER_BUTTON_CLASSES` (red)
- Adds new `NEUTRAL_BUTTON_CLASSES` style for secondary buttons with neutral background and border
- Updates "Load Game" and "New Game" buttons to use the new neutral style for visual consistency
- All 4 menu buttons now have consistent bordered styling (Continue=emerald, Load/New=neutral gray, Quit=red)

## Test plan
- [ ] Launch the game and verify all buttons have backgrounds with borders
- [ ] Verify "Continue" is emerald, "Load Game" and "New Game" are gray, "Quit" is red
- [ ] Click the Quit button and verify the application closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)