### PR TITLE
ci: add GitHub Actions workflow gating lint, typecheck, and package build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn typecheck
+      - run: yarn package

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts,.tsx ."
+    "lint": "eslint --ext .ts,.tsx .",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "keywords": [
     "electron",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running on `pull_request` to `main` and `push` to `main`.
- Single `ubuntu-latest` job on Node 20 with yarn caching: `yarn install --frozen-lockfile` → `yarn lint` → `yarn typecheck` → `yarn package`.
- Adds `"typecheck": "tsc --noEmit -p tsconfig.json"` to `package.json`. No other script or source changes.

## CI run
- First run green: https://github.com/wpinrui/grand-prix-universe/actions/runs/25276862739
- Runtime baseline: **1m18s** end-to-end (build job, cold yarn cache).

## Notes
- `--frozen-lockfile` will fail the job if `yarn.lock` and `package.json` drift, which is the prerequisite the upcoming Tier 2 Dependabot pass needs.