### PR TITLE
chore(deps): resolve minimatch/picomatch advisories and bump @dicebear/collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,9 @@
     "react-router-dom": "^7.10.1",
     "recharts": "^3.5.1",
     "three": "^0.181.2"
+  },
+  "resolutions": {
+    "minimatch": "9.0.7",
+    "picomatch": "4.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,86 +177,87 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@dicebear/adventurer-neutral@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/adventurer-neutral/-/adventurer-neutral-9.2.4.tgz#652c5a5d9a907159ace1de4153947822f320c241"
-  integrity sha512-I9IrB4ZYbUHSOUpWoUbfX3vG8FrjcW8htoQ4bEOR7TYOKKE11Mo1nrGMuHZ7GPfwN0CQeK1YVJhWqLTmtYn7Pg==
+"@dicebear/adventurer-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/adventurer-neutral/-/adventurer-neutral-9.4.2.tgz#5779570b1c0fd956781fab2e2b09da7cac3b699d"
+  integrity sha512-5xgkG/mNL4j3Q4SJGQLBU/KnU90tng8Ze5ofThD+55wi0oeY/nSAUowg6UFCmHrktjifj/MEx3CQqbpcPWtfIA==
 
-"@dicebear/adventurer@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/adventurer/-/adventurer-9.2.4.tgz#5f44452863b71da109eaf22855f8ede1a7dc69a9"
-  integrity sha512-Xvboay3VH1qe7lH17T+bA3qPawf5EjccssDiyhCX/VT0P21c65JyjTIUJV36Nsv08HKeyDscyP0kgt9nPTRKvA==
+"@dicebear/adventurer@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/adventurer/-/adventurer-9.4.2.tgz#5aa010ec20c49bcca936ce08e240bf7b888ff3bd"
+  integrity sha512-jqYp834ZmGDA9HBBDQAdgF1O2UTCwHF4vVrktXWa2Dppp1JczPL5HnVOWsjtrLmXNn61Wd6OLmBb2e6rhzp3ig==
 
-"@dicebear/avataaars-neutral@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/avataaars-neutral/-/avataaars-neutral-9.2.4.tgz#1610152c1bc8e2c7de6f03d5923f367de85f712f"
-  integrity sha512-HtBvA7elRv50QTOOsBdtYB1GVimCpGEDlDgWsu1snL5Z3d1+3dIESoXQd3mXVvKTVT8Z9ciA4TEaF09WfxDjAA==
+"@dicebear/avataaars-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/avataaars-neutral/-/avataaars-neutral-9.4.2.tgz#5db00cb9e5404aff10879672699aaa57e48e0129"
+  integrity sha512-/eNrp0YCNJRwQXqOloLm1+3Ss2C+pMpUQIGkbEnGsP1UK+13Ge80ggDDof1HpdqvG9HAZcKa7hnbG/0HSwyDSw==
 
-"@dicebear/avataaars@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/avataaars/-/avataaars-9.2.4.tgz#2ce16ffb1db575942d27e8cfafde826afd0926b6"
-  integrity sha512-QKNBtA/1QGEzR+JjS4XQyrFHYGbzdOp0oa6gjhGhUDrMegDFS8uyjdRfDQsFTebVkyLWjgBQKZEiDqKqHptB6A==
+"@dicebear/avataaars@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/avataaars/-/avataaars-9.4.2.tgz#94c3b1d86101e4ad9122ad0f13cf2f7ac39c2aad"
+  integrity sha512-3x9jKFkOkFSPmpTbt9xvhiU2E1GX7beCSsX0tXRUShj8x6+5Ks9yBRT1VlkySbnXrZ/GglADGg7vJ/D2uIx1Yw==
 
-"@dicebear/big-ears-neutral@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/big-ears-neutral/-/big-ears-neutral-9.2.4.tgz#9d21651f8f7942a879fc5441ca5b786bd5ba87c5"
-  integrity sha512-pPjYu80zMFl43A9sa5+tAKPkhp4n9nd7eN878IOrA1HAowh/XePh5JN8PTkNFS9eM+rnN9m8WX08XYFe30kLYw==
+"@dicebear/big-ears-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/big-ears-neutral/-/big-ears-neutral-9.4.2.tgz#f8d6cdae3baa348a339d8047efc2e2ea4b1a074d"
+  integrity sha512-M8Ozmzza4eY4hpLOYULgJxMYmBA0CsBnrE15/xw6LZkEREXnrX5z0NJsf8hUfdyF6BWZ+RBgzoiav32DAC5zcg==
 
-"@dicebear/big-ears@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/big-ears/-/big-ears-9.2.4.tgz#efc62a4a539f4cda20e6351f6335a80c438416bc"
-  integrity sha512-U33tbh7Io6wG6ViUMN5fkWPER7hPKMaPPaYgafaYQlCT4E7QPKF2u8X1XGag3jCKm0uf4SLXfuZ8v+YONcHmNQ==
+"@dicebear/big-ears@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/big-ears/-/big-ears-9.4.2.tgz#65d32bac804f4bb615cf9afaba667e35e40565e1"
+  integrity sha512-mNfz3ppNA7UBq0IO3nXCiV5pFPG7c1DfzRB0foNU2Wo1XXT8FIcSY2BvDlYqorZTOUOz7dHb0vx06hqvG0HP5w==
 
-"@dicebear/big-smile@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/big-smile/-/big-smile-9.2.4.tgz#51cd7e94ec0c5e843cef54a3af95e329464f782b"
-  integrity sha512-zeEfXOOXy7j9tfkPLzfQdLBPyQsctBetTdEfKRArc1k3RUliNPxfJG9j88+cXQC6GXrVW2pcT2X50NSPtugCFQ==
+"@dicebear/big-smile@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/big-smile/-/big-smile-9.4.2.tgz#137f9a5b54f62291f2fc36da626125806afb6dcc"
+  integrity sha512-hmT5i7rcPPhStjZyg28pbIhdTnnMBzK3RObI0vKCpY30EFrzaPkkdDL6Ck5fAFBdvDIW1EpOJkenyR0XPmhgbQ==
 
-"@dicebear/bottts-neutral@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/bottts-neutral/-/bottts-neutral-9.2.4.tgz#5a0b111d536f9de989cdddf41f1df28f6d0813cf"
-  integrity sha512-eMVdofdD/udHsKIaeWEXShDRtiwk7vp4FjY7l0f79vIzfhkIsXKEhPcnvHKOl/yoArlDVS3Uhgjj0crWTO9RJA==
+"@dicebear/bottts-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/bottts-neutral/-/bottts-neutral-9.4.2.tgz#a9ce66d50e600a9ee508fece651817b050406ff2"
+  integrity sha512-kFNwWt6j+gzZ5n5Pz7WVwePubREAQOF8ZwWA9ztwVYDVMLnOChWbAofy5FED4j5md2MXFH2EgLCFCMr5K2BmIA==
 
-"@dicebear/bottts@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/bottts/-/bottts-9.2.4.tgz#b347c2c289b18bebb03e1b2c7cfd0c0c509e36a9"
-  integrity sha512-4CTqrnVg+NQm6lZ4UuCJish8gGWe8EqSJrzvHQRO5TEyAKjYxbTdVqejpkycG1xkawha4FfxsYgtlSx7UwoVMw==
+"@dicebear/bottts@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/bottts/-/bottts-9.4.2.tgz#df7501723d309011e31b122484cfcef643a01f98"
+  integrity sha512-tsx+dII7EFUCVA8URj66G1GqORCCVduCAx4dY2prEY2IeFianVpkntXuFsWZ9BBGx1NZFndvDith5oTwKMQPbQ==
 
 "@dicebear/collection@^9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/collection/-/collection-9.2.4.tgz#33f470e7709f94ada8f93291a76a58cd3df10907"
-  integrity sha512-I1wCUp0yu5qSIeMQHmDYXQIXKkKjcja/SYBxppPkYFXpR2alxb0k9/swFDdMbkY6a1c9AT1kI1y+Pg6ywQ2rTA==
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/collection/-/collection-9.4.2.tgz#16495cd2788614aaf2c783e539125b0dbf14bbe1"
+  integrity sha512-KArubv7if8H7j9sIfpDK2hJJqrdNVR5zMPAMOSpIU2JPyXx8TC9o5wsmXb8il5wOHgaS9Q/cla7jUNIiDD7Gsg==
   dependencies:
-    "@dicebear/adventurer" "9.2.4"
-    "@dicebear/adventurer-neutral" "9.2.4"
-    "@dicebear/avataaars" "9.2.4"
-    "@dicebear/avataaars-neutral" "9.2.4"
-    "@dicebear/big-ears" "9.2.4"
-    "@dicebear/big-ears-neutral" "9.2.4"
-    "@dicebear/big-smile" "9.2.4"
-    "@dicebear/bottts" "9.2.4"
-    "@dicebear/bottts-neutral" "9.2.4"
-    "@dicebear/croodles" "9.2.4"
-    "@dicebear/croodles-neutral" "9.2.4"
-    "@dicebear/dylan" "9.2.4"
-    "@dicebear/fun-emoji" "9.2.4"
-    "@dicebear/glass" "9.2.4"
-    "@dicebear/icons" "9.2.4"
-    "@dicebear/identicon" "9.2.4"
-    "@dicebear/initials" "9.2.4"
-    "@dicebear/lorelei" "9.2.4"
-    "@dicebear/lorelei-neutral" "9.2.4"
-    "@dicebear/micah" "9.2.4"
-    "@dicebear/miniavs" "9.2.4"
-    "@dicebear/notionists" "9.2.4"
-    "@dicebear/notionists-neutral" "9.2.4"
-    "@dicebear/open-peeps" "9.2.4"
-    "@dicebear/personas" "9.2.4"
-    "@dicebear/pixel-art" "9.2.4"
-    "@dicebear/pixel-art-neutral" "9.2.4"
-    "@dicebear/rings" "9.2.4"
-    "@dicebear/shapes" "9.2.4"
-    "@dicebear/thumbs" "9.2.4"
+    "@dicebear/adventurer" "9.4.2"
+    "@dicebear/adventurer-neutral" "9.4.2"
+    "@dicebear/avataaars" "9.4.2"
+    "@dicebear/avataaars-neutral" "9.4.2"
+    "@dicebear/big-ears" "9.4.2"
+    "@dicebear/big-ears-neutral" "9.4.2"
+    "@dicebear/big-smile" "9.4.2"
+    "@dicebear/bottts" "9.4.2"
+    "@dicebear/bottts-neutral" "9.4.2"
+    "@dicebear/croodles" "9.4.2"
+    "@dicebear/croodles-neutral" "9.4.2"
+    "@dicebear/dylan" "9.4.2"
+    "@dicebear/fun-emoji" "9.4.2"
+    "@dicebear/glass" "9.4.2"
+    "@dicebear/icons" "9.4.2"
+    "@dicebear/identicon" "9.4.2"
+    "@dicebear/initials" "9.4.2"
+    "@dicebear/lorelei" "9.4.2"
+    "@dicebear/lorelei-neutral" "9.4.2"
+    "@dicebear/micah" "9.4.2"
+    "@dicebear/miniavs" "9.4.2"
+    "@dicebear/notionists" "9.4.2"
+    "@dicebear/notionists-neutral" "9.4.2"
+    "@dicebear/open-peeps" "9.4.2"
+    "@dicebear/personas" "9.4.2"
+    "@dicebear/pixel-art" "9.4.2"
+    "@dicebear/pixel-art-neutral" "9.4.2"
+    "@dicebear/rings" "9.4.2"
+    "@dicebear/shapes" "9.4.2"
+    "@dicebear/thumbs" "9.4.2"
+    "@dicebear/toon-head" "9.4.2"
 
 "@dicebear/core@^9.4.1":
   version "9.4.1"
@@ -265,110 +266,115 @@
   dependencies:
     "@types/json-schema" "^7.0.15"
 
-"@dicebear/croodles-neutral@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/croodles-neutral/-/croodles-neutral-9.2.4.tgz#68e0abee58adb884d875b677b61dbb1676c1dfee"
-  integrity sha512-8vAS9lIEKffSUVx256GSRAlisB8oMX38UcPWw72venO/nitLVsyZ6hZ3V7eBdII0Onrjqw1RDndslQODbVcpTw==
+"@dicebear/croodles-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/croodles-neutral/-/croodles-neutral-9.4.2.tgz#74b31e97757db016679e5eb3de75ab68f7eb26c4"
+  integrity sha512-oG5IeUdtiYshQ89gkAVcl5w3xAEi5UZX2fTzIyelpBPCG176l7VuuFzlxi2umnB3E6LVHYy06DXvUo/p+rXB2Q==
 
-"@dicebear/croodles@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/croodles/-/croodles-9.2.4.tgz#c306220bdbeaf349a48c0cda3be4f06b95884826"
-  integrity sha512-CqT0NgVfm+5kd+VnjGY4WECNFeOrj5p7GCPTSEA7tCuN72dMQOX47P9KioD3wbExXYrIlJgOcxNrQeb/FMGc3A==
+"@dicebear/croodles@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/croodles/-/croodles-9.4.2.tgz#d5a29f2f30746cf9e1fa8ecb26272a7d4382cfac"
+  integrity sha512-6VoO0JviIf7dKKMBTL/SMXxWhnXHaZuzufX90G0nXxS77ELG1YkGNMaZzawizN4C09Gbya2gJkozqrWiJN/aGw==
 
-"@dicebear/dylan@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/dylan/-/dylan-9.2.4.tgz#c33355b2a09a34d3007ea0b3d528ab71cbff87ee"
-  integrity sha512-tiih1358djAq0jDDzmW3N3S4C3ynC2yn4hhlTAq/MaUAQtAi47QxdHdFGdxH0HBMZKqA4ThLdVk3yVgN4xsukg==
+"@dicebear/dylan@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/dylan/-/dylan-9.4.2.tgz#d7b3905b2be999aab2a51aab69545db47301871a"
+  integrity sha512-1vQvRu9x9DrwFxhFaIU2rf0EUL04yDTbAt7fHyAjM0mEsKzTD4mRNf95tCRuavCoW6W48u7A/OY6jyIub6kxLQ==
 
-"@dicebear/fun-emoji@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/fun-emoji/-/fun-emoji-9.2.4.tgz#fc16e872755b9fbdd4eaf30f48a244f344ccc1f9"
-  integrity sha512-Od729skczse1HvHekgEFv+mSuJKMC4sl5hENGi/izYNe6DZDqJrrD0trkGT/IVh/SLXUFbq1ZFY9I2LoUGzFZg==
+"@dicebear/fun-emoji@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/fun-emoji/-/fun-emoji-9.4.2.tgz#4b48663c1d79dfd7e4e5e5783d9ff24192ac42a0"
+  integrity sha512-kqB6LPkdYCdEU/mwbyz34xLzoNUKL6ARcoo3fr5ASq9D6ZE07qIKybC3xv5+CPz7VmspJ1Q3c/VVWVMDRP7Twg==
 
-"@dicebear/glass@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/glass/-/glass-9.2.4.tgz#83faa9b9e93ab35a5d6c847b4db1a7928c483961"
-  integrity sha512-5lxbJode1t99eoIIgW0iwZMoZU4jNMJv/6vbsgYUhAslYFX5zP0jVRscksFuo89TTtS7YKqRqZAL3eNhz4bTDw==
+"@dicebear/glass@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/glass/-/glass-9.4.2.tgz#608d93350c39158361c3b3c2ae392a179c3b20dd"
+  integrity sha512-z5qUogHQ1b6UJ2zCqT848mU2U9DKbVDhiX6GPDjD7tYLisCCJVisH9p6WyNdHvflUd4SHkA6gRqVJIh2v2HnTA==
 
-"@dicebear/icons@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/icons/-/icons-9.2.4.tgz#f5a0673a3b2a39995c01ca7f5df637bd8b04383d"
-  integrity sha512-bRsK1qj8u9Z76xs8XhXlgVr/oHh68tsHTJ/1xtkX9DeTQTSamo2tS26+r231IHu+oW3mePtFnwzdG9LqEPRd4A==
+"@dicebear/icons@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/icons/-/icons-9.4.2.tgz#92d32d8d1150a786833424f2c323207e3e4e6a2e"
+  integrity sha512-QSMMz0NA03ypSGhXC8HQX8FSj8lYT+/5yqH+/N03OH2IjL0q7wwGZ7nqsrtlRp76O5WqMTwGfSbTUUYPjFr+Xw==
 
-"@dicebear/identicon@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/identicon/-/identicon-9.2.4.tgz#aa6eb1dc747d2a517ffaf610bee101e9840a333e"
-  integrity sha512-R9nw/E8fbu9HltHOqI9iL/o9i7zM+2QauXWMreQyERc39oGR9qXiwgBxsfYGcIS4C85xPyuL5B3I2RXrLBlJPg==
+"@dicebear/identicon@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/identicon/-/identicon-9.4.2.tgz#b72f8fb9874218598b12b03526dcadd051b33849"
+  integrity sha512-JVDSmZsv11mSWqwAktK5x9Bslht2xY3TFUn8xzu6slAYe1Z7hEXZ76eb+UJ6F4qEzdwZ7xPWzAS6Nb0Y3A0pww==
 
-"@dicebear/initials@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/initials/-/initials-9.2.4.tgz#b04e02d25561cd395df75f26b4376d420b2dd43f"
-  integrity sha512-4SzHG5WoQZl1TGcpEZR4bdsSkUVqwNQCOwWSPAoBJa3BNxbVsvL08LF7I97BMgrCoknWZjQHUYt05amwTPTKtg==
+"@dicebear/initials@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/initials/-/initials-9.4.2.tgz#6eab64a9913e57dac41a5a508f2fe68c7eb23c1b"
+  integrity sha512-yePuIUasmwtl9IrtB6rEzE/zb5fImKP/neW0CdcTC2MwLgMuP1GLHEGRgg1zI8exIh+PMv1YdLGyyUuRTE2Qpw==
 
-"@dicebear/lorelei-neutral@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/lorelei-neutral/-/lorelei-neutral-9.2.4.tgz#65320367fd374ae6dd3b3412bb70b7e4c105f3d4"
-  integrity sha512-bWq2/GonbcJULtT+B/MGcM2UnA7kBQoH+INw8/oW83WI3GNTZ6qEwe3/W4QnCgtSOhUsuwuiSULguAFyvtkOZQ==
+"@dicebear/lorelei-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/lorelei-neutral/-/lorelei-neutral-9.4.2.tgz#88da92634c0c18145a65611c00ece78e6d783bea"
+  integrity sha512-yspanTthA5vh6iCdeLzn6xZ4yYMYRcfcxblcgSvHTF1ut0bjAXtw5SXzZ6aJTrJWiHkzYOQuTOR6GVYiW80Q7w==
 
-"@dicebear/lorelei@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/lorelei/-/lorelei-9.2.4.tgz#2bf6e2d66a0f0651365935519427ed41fb713ccc"
-  integrity sha512-eS4mPYUgDpo89HvyFAx/kgqSSKh8W4zlUA8QJeIUCWTB0WpQmeqkSgIyUJjGDYSrIujWi+zEhhckksM5EwW0Dg==
+"@dicebear/lorelei@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/lorelei/-/lorelei-9.4.2.tgz#bb37c41cac61e1878b09a819c4f50153b8d50d05"
+  integrity sha512-YMv6vnriW6VLFDsreKuOnUFFno6SRe7+7X7R7zPY0rZ+MaHX9V3jcioIG+1PSjIHEDfOLUHpr5vd1JBWv8y7UA==
 
-"@dicebear/micah@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/micah/-/micah-9.2.4.tgz#7275c5c2f5e84cef8cf9c0cb8224e121c006d462"
-  integrity sha512-XNWJ8Mx+pncIV8Ye0XYc/VkMiax8kTxcP3hLTC5vmELQyMSLXzg/9SdpI+W/tCQghtPZRYTT3JdY9oU9IUlP2g==
+"@dicebear/micah@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/micah/-/micah-9.4.2.tgz#1ead10ff31d63a9c0fc55f4bb124a7782080b7ce"
+  integrity sha512-e4D3W/OlChSsLo7Llwsy0J18vk0azJqF/uFoY+EKACCNHBc1HGNsqVvu2CTf+OWOA8wTyAK6UkjBN5p01r7D+g==
 
-"@dicebear/miniavs@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/miniavs/-/miniavs-9.2.4.tgz#e85bad761397ddf2f4dcf6a3d20b3f6ce3ad62a8"
-  integrity sha512-k7IYTAHE/4jSO6boMBRrNlqPT3bh7PLFM1atfe0nOeCDwmz/qJUBP3HdONajbf3fmo8f2IZYhELrNWTOE7Ox3Q==
+"@dicebear/miniavs@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/miniavs/-/miniavs-9.4.2.tgz#9971cfb7c72507a2d1cbda62ad3da9e38dc9196f"
+  integrity sha512-wLwyFNNUnDRd3BbhSBhXR0XEpX8sG0/xDA5M/OkDoapLqZnnI48YLUSDd2N5QTAVMmcSEuZOYxkcnj7WW79vlg==
 
-"@dicebear/notionists-neutral@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/notionists-neutral/-/notionists-neutral-9.2.4.tgz#a69ab007a39af6d3fb19822de5d7a7deb7e62d05"
-  integrity sha512-fskWzBVxQzJhCKqY24DGZbYHSBaauoRa1DgXM7+7xBuksH7mfbTmZTvnUAsAqJYBkla8IPb4ERKduDWtlWYYjQ==
+"@dicebear/notionists-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/notionists-neutral/-/notionists-neutral-9.4.2.tgz#08b99e589fdade9d7c8e79317eac19650ddefba4"
+  integrity sha512-AyD9kEfVxQUwDGf4Op059gVmYIOAkTKg3dtE9h9mEKP7zl/kMy5B67BFFOo7sB0mXCjzAegZ6ekGU02E8+hIHw==
 
-"@dicebear/notionists@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/notionists/-/notionists-9.2.4.tgz#ee6b7dede9213e69aab5c005beed80678afcc0a5"
-  integrity sha512-zcvpAJ93EfC0xQffaPZQuJPShwPhnu9aTcoPsaYGmw0oEDLcv2XYmDhUUdX84QYCn6LtCZH053rHLVazRW+OGw==
+"@dicebear/notionists@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/notionists/-/notionists-9.4.2.tgz#9f7ee80a7793ab421e07c740bdc03a7c5bb7be70"
+  integrity sha512-ZCySq+nxcD/x4xyYgytcj2N9uY3gxrL+qpnmOdp2BdA221KacVrxlsUPpIgEMqxS2rMmBQXfxg129Pzn4ycIpA==
 
-"@dicebear/open-peeps@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/open-peeps/-/open-peeps-9.2.4.tgz#897866252ae0aecd1366197486d4196436ee62e6"
-  integrity sha512-s6nwdjXFsplqEI7imlsel4Gt6kFVJm6YIgtZSpry0UdwDoxUUudei5bn957j9lXwVpVUcRjJW+TuEKztYjXkKQ==
+"@dicebear/open-peeps@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/open-peeps/-/open-peeps-9.4.2.tgz#072dfb20ca9d47a72c40ba1e1b898feb0962ae10"
+  integrity sha512-i01tLgtp2g937T81sVeAOVlqsCtiTck/Kw20g7hN80+7xrXjOUepz2HPLy3HeiMjwjMGRy5o54kSd0/8Ht4Dqg==
 
-"@dicebear/personas@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/personas/-/personas-9.2.4.tgz#032ac644792ff02e2ede8dc2cd71092a20ff74dc"
-  integrity sha512-JNim8RfZYwb0MfxW6DLVfvreCFIevQg+V225Xe5tDfbFgbcYEp4OU/KaiqqO2476OBjCw7i7/8USbv2acBhjwA==
+"@dicebear/personas@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/personas/-/personas-9.4.2.tgz#9fe6affb3da3c7b8c9c546bc7a4aff587ee8bcd2"
+  integrity sha512-NJlkvI5F5gugt6t2+7QrYNTwQC7+4IQZS3vG0dYk2BncxOHax0BuLovdSdiAesTL4ZkytFYIydWmKmV2/xcUwg==
 
-"@dicebear/pixel-art-neutral@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/pixel-art-neutral/-/pixel-art-neutral-9.2.4.tgz#789f2aae5d74a56de84d1119e4898338004a96b3"
-  integrity sha512-ZITPLD1cPN4GjKkhWi80s7e5dcbXy34ijWlvmxbc4eb/V7fZSsyRa9EDUW3QStpo+xrCJLcLR+3RBE5iz0PC/A==
+"@dicebear/pixel-art-neutral@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/pixel-art-neutral/-/pixel-art-neutral-9.4.2.tgz#781faf023f1be3c6576a3bb366d4aa93efd34a7d"
+  integrity sha512-9e9Lz554uQvWaXV2P17ss+hPa6rTyuAKBtB8zk8ECjHiZzIl61N/KcTVLZ4dILVZwj7gYriaLo16QEqvL2GJCg==
 
-"@dicebear/pixel-art@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/pixel-art/-/pixel-art-9.2.4.tgz#ea1458d36edb489031c998113126208ffa18c0b2"
-  integrity sha512-4Ao45asieswUdlCTBZqcoF/0zHR3OWUWB0Mvhlu9b1Fbc6IlPBiOfx2vsp6bnVGVnMag58tJLecx2omeXdECBQ==
+"@dicebear/pixel-art@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/pixel-art/-/pixel-art-9.4.2.tgz#02e2643a3ea3f45af88d44f067c8bdfe830073ee"
+  integrity sha512-peHf7oKICDgBZ8dUyj+txPnS7VZEWgvKE+xW4mNQqBt6dYZIjmva2shOVHn0b1JU+FDxMx3uIkWVixKdUq4WGg==
 
-"@dicebear/rings@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/rings/-/rings-9.2.4.tgz#1a74b668c705688810a502fad8aa1163be4a4a7d"
-  integrity sha512-teZxELYyV2ogzgb5Mvtn/rHptT0HXo9SjUGS4A52mOwhIdHSGGU71MqA1YUzfae9yJThsw6K7Z9kzuY2LlZZHA==
+"@dicebear/rings@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/rings/-/rings-9.4.2.tgz#073a4a7b9c9782db8f767023cbbcdaa1024cc59d"
+  integrity sha512-Pc3ymWrRDQPJFNrbbLt7RJrzGvUuuxUiDkrfLhoVE+B6mZWEL1PC78DPbS1yUWYLErJOpJuM2GSwXmTbVjWf+g==
 
-"@dicebear/shapes@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/shapes/-/shapes-9.2.4.tgz#534fd90d7b73845438984c0afb6160ac63aaf084"
-  integrity sha512-MhK9ZdFm1wUnH4zWeKPRMZ98UyApolf5OLzhCywfu38tRN6RVbwtBRHc/42ZwoN1JU1JgXr7hzjYucMqISHtbA==
+"@dicebear/shapes@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/shapes/-/shapes-9.4.2.tgz#a3509c51fe9eca05e09a499be42536b93461b10b"
+  integrity sha512-AFL6jAaiLztvcqyq+ds+lWZu6Vbp3PlGWhJeJRm842jxtiluJpl6r4f6nUXP2fdMz7MNpDzXfLooQK9E04NbUQ==
 
-"@dicebear/thumbs@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@dicebear/thumbs/-/thumbs-9.2.4.tgz#c94c0b9e9bb6c0cfa039bce17163243564ddd969"
-  integrity sha512-EL4sMqv9p2+1Xy3d8e8UxyeKZV2+cgt3X2x2RTRzEOIIhobtkL8u6lJxmJbiGbpVtVALmrt5e7gjmwqpryYDpg==
+"@dicebear/thumbs@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/thumbs/-/thumbs-9.4.2.tgz#674ca17c154ecce89d2ba5c05a5f72af616ab269"
+  integrity sha512-ccWvDBqbkWS5uzHbsg5L6uML6vBfX7jT3J3jHCQksvz8haHItxTK02w+6e1UavZUsvza4lG5X/XY3eji3siJ4Q==
+
+"@dicebear/toon-head@9.4.2":
+  version "9.4.2"
+  resolved "https://registry.yarnpkg.com/@dicebear/toon-head/-/toon-head-9.4.2.tgz#af904b7c73b7c7e555e9c55ecea830009de0d9f4"
+  integrity sha512-lwFeSXyAnaKnCfMt9TiJwnD1cXQUGkey/0h6i/+4TVHVMCz5/Ri5u1ynovPNHy1SnBf858QwoXHkxilGLwQX/g==
 
 "@dimforge/rapier3d-compat@~0.12.0":
   version "0.12.0"
@@ -2425,10 +2431,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
@@ -2466,20 +2472,12 @@ boolean@^3.0.1:
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.2.0.tgz#9e5294af4e98314494cbb17979fa54ca159f116b"
   integrity sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==
 
-brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+brace-expansion@^5.0.2:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
+  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
   dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
-  dependencies:
-    balanced-match "^1.0.0"
+    balanced-match "^4.0.2"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -2749,11 +2747,6 @@ compare-version@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
   integrity sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -4837,26 +4830,12 @@ mimic-response@^3.1.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
-minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@9.0.7, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^5.0.1, minimatch@^9.0.3, minimatch@^9.0.4:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.7.tgz#d76c4d0b3b527877016d6cc1b9922fc8e0ffe7b0"
+  integrity sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==
   dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^9.0.3, minimatch@^9.0.4:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
-  dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^5.0.2"
 
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
@@ -5285,15 +5264,10 @@ picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
-
-picomatch@^4.0.2, picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+picomatch@4.0.4, picomatch@^2.3.1, picomatch@^4.0.2, picomatch@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pify@^2.0.0:
   version "2.3.0"


### PR DESCRIPTION
## Summary
Tier 2 cheap-win Dependabot cleanup per Paige's brief. Single PR, three changes:

- **`@dicebear/collection`**: `yarn upgrade` consumed 9.4.2 (newer than the 9.4.1 fix-line). Clears `@dicebear/initials` alert.
- **`minimatch` resolution → `9.0.7`** (top-level `resolutions` block in `package.json`). Forces dedupe to the highest in-major fix.
- **`picomatch` resolution → `4.0.4`** (same).

`package.json` direct-dep ranges are unchanged. Only `yarn.lock` regenerates.

## Alerts expected to clear (8 total)
Per Rachel's audit (`.agent/research.md`):

- `minimatch` — alerts **#21, #25, #26, #27, #29** (5 high)
- `picomatch` — alerts **#41, #83** (2 medium)
- `@dicebear/initials` — alert **#37** (1 medium)

The remaining 13 Tier 2 alerts (`react-router`, `tar`, `serialize-javascript`, `@tootallnate/once`, `tmp@0.0.x`) are gated on upstream parent releases and not addressable here.

## Local validation (all green on this branch)
- `yarn install --frozen-lockfile` — clean (`success Already up-to-date`).
- `yarn lint` — clean.
- `yarn typecheck` — clean.
- `yarn package` — clean.
- `yarn start` — Ivan verified renderer loads, no DevTools console errors.

## CI run
- Green end-to-end: https://github.com/wpinrui/grand-prix-universe/actions/runs/25277239294 (build pass, 1m17s).

## Notes / decisions
- Yarn classic 1.22 does not support per-major version selectors in `resolutions` (Berry-only). Forcing `minimatch@9.0.7` and `picomatch@4.0.4` therefore overrides parents that declare `^3.x` / `^5.x` for minimatch and `^2.x` for picomatch — yarn emits "incompatible with requested version" warnings on install. Despite that, lint/typecheck/package and dev-server boot all succeed, so the API drift is tolerable in practice for our consumers (eslint stack, electron tooling, vite stack).

Closes nothing (no tracking issue exists for this Tier 2 sweep).