### PR TITLE
feat(sponsorship): Tier 1 — slot enforcement, confirm gate, signing consequences, monthly income, inbox restructure

### DIFF
--- a/scripts/sim-sponsors.ts
+++ b/scripts/sim-sponsors.ts
@@ -1,0 +1,255 @@
+/**
+ * Sponsor simulation CLI — used by Tricia (Tester) to verify Tier 1 sponsorship mechanics.
+ *
+ * Usage:
+ *   npx ts-node --compiler-options '{"module":"commonjs"}' scripts/sim-sponsors.ts [scenario]
+ *
+ * Scenarios:
+ *   signing      Simulate a completed signing and print pre/post team.budget
+ *   monthly N    Fast-forward N months from an active deal and print cumulative delta
+ *   slots        Attempt to initiate a negotiation when all slots of a tier are filled
+ *
+ * All scenarios run by default when no argument is supplied.
+ */
+
+import { randomUUID } from 'crypto';
+import type {
+  GameState,
+  SponsorNegotiation,
+  SponsorContractTerms,
+  Sponsor,
+  Team,
+} from '../src/shared/domain/types';
+import {
+  SponsorTier,
+  SponsorPlacement,
+  NegotiationPhase,
+  StakeholderType,
+} from '../src/shared/domain/types';
+import { SPONSOR_SLOT_COUNTS } from '../src/shared/domain/engine-utils';
+import {
+  createSponsorContractFromNegotiation,
+  generateSponsorSigningEvent,
+} from '../src/main/services/contract-creator';
+import { applyMonthlyIncomeTick } from '../src/main/services/sponsor-mechanics';
+
+// ---------------------------------------------------------------------------
+// Minimal state builders
+// ---------------------------------------------------------------------------
+
+function makeTeam(id: string, budget: number): Team {
+  return {
+    id,
+    name: 'Test Team',
+    shortName: 'TEST',
+    color: '#ff0000',
+    budget,
+    reputation: 70,
+    initialSponsorIds: [],
+  } as unknown as Team;
+}
+
+function makeSponsor(id: string, tier: SponsorTier): Sponsor {
+  return {
+    id,
+    name: 'Test Sponsor',
+    industry: 'technology',
+    tier,
+    baseMonthlyPayment: 50_000,
+    minReputation: 0,
+    rivalGroup: null,
+    logoUrl: null,
+  };
+}
+
+function makeMinimalState(teamId: string, budget: number, sponsorTier: SponsorTier = SponsorTier.Major): GameState {
+  const team = makeTeam(teamId, budget);
+  const sponsor = makeSponsor('sponsor-1', sponsorTier);
+  return {
+    teams: [team],
+    sponsors: [sponsor],
+    sponsorDeals: [],
+    negotiations: [],
+    calendarEvents: [],
+    events: [],
+    currentDate: { year: 2025, month: 1, day: 15 },
+    currentSeason: { seasonNumber: 1 } as GameState['currentSeason'],
+    player: { teamId } as GameState['player'],
+  } as unknown as GameState;
+}
+
+function makeNegotiation(
+  teamId: string,
+  sponsorId: string,
+  terms: SponsorContractTerms
+): SponsorNegotiation {
+  return {
+    id: randomUUID(),
+    stakeholderType: StakeholderType.Sponsor,
+    teamId,
+    sponsorId,
+    phase: NegotiationPhase.PendingPlayerConfirmation,
+    forSeason: 2,
+    startedDate: { year: 2025, month: 1, day: 1 },
+    lastActivityDate: { year: 2025, month: 1, day: 15 },
+    rounds: [
+      {
+        roundNumber: 1,
+        offeredBy: 'counterparty' as const,
+        terms,
+        offeredDate: { year: 2025, month: 1, day: 1 },
+        expiresDate: { year: 2025, month: 2, day: 1 },
+      },
+    ],
+    currentRound: 1,
+    maxRounds: 5,
+    relationshipScoreBefore: 50,
+    hasCompetingOffer: false,
+    isProactiveOutreach: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — Signing bonus
+// ---------------------------------------------------------------------------
+
+function scenarySigning() {
+  console.log('\n=== SCENARIO: signing ===');
+
+  const teamId = 'team-1';
+  const signingBonus = 200_000;
+  const monthlyPayment = 50_000;
+  const startBudget = 1_000_000;
+
+  const state = makeMinimalState(teamId, startBudget);
+  const terms: SponsorContractTerms = {
+    signingBonus,
+    monthlyPayment,
+    duration: 2,
+    placement: SponsorPlacement.Secondary,
+  };
+
+  const negotiation = makeNegotiation(teamId, 'sponsor-1', terms);
+  state.negotiations.push(negotiation);
+
+  // Complete the negotiation (set phase to Completed as signSponsorDeal does)
+  negotiation.phase = NegotiationPhase.Completed;
+
+  const budgetBefore = state.teams[0].budget;
+  console.log(`Budget before Sign:  $${budgetBefore.toLocaleString()}`);
+
+  const result = createSponsorContractFromNegotiation(negotiation, state);
+  if (result) {
+    generateSponsorSigningEvent(state, result, true);
+  }
+
+  const budgetAfter = state.teams[0].budget;
+  console.log(`Budget after Sign:   $${budgetAfter.toLocaleString()}`);
+  console.log(`Delta:               $${(budgetAfter - budgetBefore).toLocaleString()} (expected $${signingBonus.toLocaleString()})`);
+
+  const passed = budgetAfter - budgetBefore === signingBonus;
+  console.log(`Result: ${passed ? 'PASS ✓' : 'FAIL ✗'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — Monthly income tick
+// ---------------------------------------------------------------------------
+
+function scenarioMonthly(months: number) {
+  console.log(`\n=== SCENARIO: monthly (${months} months) ===`);
+
+  const teamId = 'team-1';
+  const monthlyPayment = 50_000;
+  const startBudget = 1_000_000;
+
+  const state = makeMinimalState(teamId, startBudget);
+
+  // Plant an active deal directly (as if already signed)
+  state.sponsorDeals.push({
+    sponsorId: 'sponsor-1',
+    teamId,
+    tier: SponsorTier.Major,
+    signingBonus: 0,
+    monthlyPayment,
+    guaranteed: true,
+    startSeason: 1,
+    endSeason: 3,
+  });
+
+  const budgetBefore = state.teams[0].budget;
+  console.log(`Budget before ${months} month(s): $${budgetBefore.toLocaleString()}`);
+
+  for (let i = 0; i < months; i++) {
+    applyMonthlyIncomeTick(state);
+  }
+
+  const budgetAfter = state.teams[0].budget;
+  const delta = budgetAfter - budgetBefore;
+  const expected = monthlyPayment * months;
+  console.log(`Budget after ${months} month(s):  $${budgetAfter.toLocaleString()}`);
+  console.log(`Delta:    $${delta.toLocaleString()} (expected $${expected.toLocaleString()})`);
+
+  const passed = delta === expected;
+  console.log(`Result: ${passed ? 'PASS ✓' : 'FAIL ✗'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — Slot enforcement
+// ---------------------------------------------------------------------------
+
+function scenarioSlots() {
+  console.log('\n=== SCENARIO: slots ===');
+
+  const teamId = 'team-1';
+  const tier = SponsorTier.Title; // Only 1 slot
+  const state = makeMinimalState(teamId, 1_000_000, tier);
+
+  // Fill the only Title slot
+  state.sponsorDeals.push({
+    sponsorId: 'sponsor-1',
+    teamId,
+    tier,
+    signingBonus: 0,
+    monthlyPayment: 100_000,
+    guaranteed: true,
+    startSeason: 1,
+    endSeason: 3,
+  });
+
+  console.log(`Title slots allowed:   ${SPONSOR_SLOT_COUNTS[tier]}`);
+  console.log(`Active title deals:    ${state.sponsorDeals.filter((d) => d.teamId === teamId && d.tier === tier).length}`);
+
+  // Attempt to start a new negotiation (same logic as game-state-manager.startSponsorNegotiation)
+  const activeDealsForTier = state.sponsorDeals.filter(
+    (d) => d.teamId === teamId && d.tier === tier
+  ).length;
+  const activeNegotiationsForTier = state.negotiations.filter((n) => {
+    if (n.stakeholderType !== StakeholderType.Sponsor) return false;
+    if (n.teamId !== teamId) return false;
+    if (n.phase === NegotiationPhase.Completed || n.phase === NegotiationPhase.Failed) return false;
+    const negSponsor = state.sponsors.find((s) => s.id === (n as SponsorNegotiation).sponsorId);
+    return negSponsor?.tier === tier;
+  }).length;
+  const slotCount = SPONSOR_SLOT_COUNTS[tier];
+  const blocked = activeDealsForTier + activeNegotiationsForTier >= slotCount;
+
+  console.log(`Attempt to negotiate: ${blocked ? 'BLOCKED ✓' : 'ALLOWED (unexpected ✗)'}`);
+  console.log(`Result: ${blocked ? 'PASS ✓' : 'FAIL ✗'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+function main() {
+  const scenario = process.argv[2] ?? 'all';
+  const months = parseInt(process.argv[3] ?? '3', 10);
+
+  if (scenario === 'signing' || scenario === 'all') scenarySigning();
+  if (scenario === 'monthly' || scenario === 'all') scenarioMonthly(months);
+  if (scenario === 'slots' || scenario === 'all') scenarioSlots();
+
+  console.log('\nDone.');
+}
+
+main();

--- a/scripts/sim-sponsors.ts
+++ b/scripts/sim-sponsors.ts
@@ -5,11 +5,14 @@
  *   npx ts-node --compiler-options '{"module":"commonjs"}' scripts/sim-sponsors.ts [scenario]
  *
  * Scenarios:
- *   signing      Simulate a completed signing and print pre/post team.budget
- *   monthly N    Fast-forward N months from an active deal and print cumulative delta
- *   slots        Attempt to initiate a negotiation when all slots of a tier are filled
+ *   signing      Simulate a sponsor-accepts → player Sign and print pre/post team.budget
+ *   monthly N    Fast-forward N months (active deal) and print cumulative delta
+ *   slots        Try to start a negotiation when all slots of a tier are filled
  *
  * All scenarios run by default when no argument is supplied.
+ *
+ * The CLI installs a constructed GameState onto `GameStateManager.currentState`
+ * and invokes the same methods the IPC layer calls — no parallel calculation.
  */
 
 import { randomUUID } from 'crypto';
@@ -27,10 +30,7 @@ import {
   StakeholderType,
 } from '../src/shared/domain/types';
 import { SPONSOR_SLOT_COUNTS } from '../src/shared/domain/engine-utils';
-import {
-  createSponsorContractFromNegotiation,
-  generateSponsorSigningEvent,
-} from '../src/main/services/contract-creator';
+import { GameStateManager } from '../src/main/services/game-state-manager';
 import { applyMonthlyIncomeTick } from '../src/main/services/sponsor-mechanics';
 
 // ---------------------------------------------------------------------------
@@ -62,7 +62,11 @@ function makeSponsor(id: string, tier: SponsorTier): Sponsor {
   };
 }
 
-function makeMinimalState(teamId: string, budget: number, sponsorTier: SponsorTier = SponsorTier.Major): GameState {
+function makeMinimalState(
+  teamId: string,
+  budget: number,
+  sponsorTier: SponsorTier = SponsorTier.Major
+): GameState {
   const team = makeTeam(teamId, budget);
   const sponsor = makeSponsor('sponsor-1', sponsorTier);
   return {
@@ -78,10 +82,11 @@ function makeMinimalState(teamId: string, budget: number, sponsorTier: SponsorTi
   } as unknown as GameState;
 }
 
-function makeNegotiation(
+function makePendingNegotiation(
   teamId: string,
   sponsorId: string,
-  terms: SponsorContractTerms
+  terms: SponsorContractTerms,
+  forSeason = 2
 ): SponsorNegotiation {
   return {
     id: randomUUID(),
@@ -89,7 +94,7 @@ function makeNegotiation(
     teamId,
     sponsorId,
     phase: NegotiationPhase.PendingPlayerConfirmation,
-    forSeason: 2,
+    forSeason,
     startedDate: { year: 2025, month: 1, day: 1 },
     lastActivityDate: { year: 2025, month: 1, day: 15 },
     rounds: [
@@ -109,8 +114,12 @@ function makeNegotiation(
   };
 }
 
+function installState(state: GameState): void {
+  GameStateManager.currentState = state;
+}
+
 // ---------------------------------------------------------------------------
-// Scenario 1 — Signing bonus
+// Scenario 1 — Signing bonus via real signSponsorDeal()
 // ---------------------------------------------------------------------------
 
 function scenarySigning() {
@@ -129,30 +138,32 @@ function scenarySigning() {
     placement: SponsorPlacement.Secondary,
   };
 
-  const negotiation = makeNegotiation(teamId, 'sponsor-1', terms);
+  const negotiation = makePendingNegotiation(teamId, 'sponsor-1', terms);
   state.negotiations.push(negotiation);
 
-  // Complete the negotiation (set phase to Completed as signSponsorDeal does)
-  negotiation.phase = NegotiationPhase.Completed;
+  installState(state);
 
   const budgetBefore = state.teams[0].budget;
   console.log(`Budget before Sign:  $${budgetBefore.toLocaleString()}`);
 
-  const result = createSponsorContractFromNegotiation(negotiation, state);
-  if (result) {
-    generateSponsorSigningEvent(state, result, true);
-  }
+  GameStateManager.signSponsorDeal(negotiation.id);
 
   const budgetAfter = state.teams[0].budget;
   console.log(`Budget after Sign:   $${budgetAfter.toLocaleString()}`);
   console.log(`Delta:               $${(budgetAfter - budgetBefore).toLocaleString()} (expected $${signingBonus.toLocaleString()})`);
+  console.log(`Negotiation phase:   ${negotiation.phase} (expected '${NegotiationPhase.Completed}')`);
 
-  const passed = budgetAfter - budgetBefore === signingBonus;
+  const passed =
+    budgetAfter - budgetBefore === signingBonus &&
+    negotiation.phase === NegotiationPhase.Completed;
   console.log(`Result: ${passed ? 'PASS ✓' : 'FAIL ✗'}`);
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 2 — Monthly income tick
+// Scenario 2 — Monthly income tick (real applyMonthlyIncomeTick)
+//
+// Covers the active-season filter: an inactive deal scheduled for next season
+// must not pay, and an expired deal must not pay.
 // ---------------------------------------------------------------------------
 
 function scenarioMonthly(months: number) {
@@ -163,8 +174,9 @@ function scenarioMonthly(months: number) {
   const startBudget = 1_000_000;
 
   const state = makeMinimalState(teamId, startBudget);
+  // currentSeason = 1
 
-  // Plant an active deal directly (as if already signed)
+  // Active deal (covers current season) — should pay
   state.sponsorDeals.push({
     sponsorId: 'sponsor-1',
     teamId,
@@ -175,6 +187,30 @@ function scenarioMonthly(months: number) {
     startSeason: 1,
     endSeason: 3,
   });
+  // Future deal (next season) — should NOT pay
+  state.sponsorDeals.push({
+    sponsorId: 'sponsor-future',
+    teamId,
+    tier: SponsorTier.Major,
+    signingBonus: 0,
+    monthlyPayment: 99_999,
+    guaranteed: true,
+    startSeason: 2,
+    endSeason: 3,
+  });
+  // Expired deal — should NOT pay
+  state.sponsorDeals.push({
+    sponsorId: 'sponsor-expired',
+    teamId,
+    tier: SponsorTier.Minor,
+    signingBonus: 0,
+    monthlyPayment: 88_888,
+    guaranteed: true,
+    startSeason: 0,
+    endSeason: 0,
+  });
+
+  installState(state);
 
   const budgetBefore = state.teams[0].budget;
   console.log(`Budget before ${months} month(s): $${budgetBefore.toLocaleString()}`);
@@ -187,14 +223,14 @@ function scenarioMonthly(months: number) {
   const delta = budgetAfter - budgetBefore;
   const expected = monthlyPayment * months;
   console.log(`Budget after ${months} month(s):  $${budgetAfter.toLocaleString()}`);
-  console.log(`Delta:    $${delta.toLocaleString()} (expected $${expected.toLocaleString()})`);
+  console.log(`Delta:    $${delta.toLocaleString()} (expected $${expected.toLocaleString()} — only the active deal should pay)`);
 
   const passed = delta === expected;
   console.log(`Result: ${passed ? 'PASS ✓' : 'FAIL ✗'}`);
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 3 — Slot enforcement
+// Scenario 3 — Slot enforcement via real startSponsorNegotiation()
 // ---------------------------------------------------------------------------
 
 function scenarioSlots() {
@@ -215,25 +251,31 @@ function scenarioSlots() {
     startSeason: 1,
     endSeason: 3,
   });
+  // Add a second sponsor of the same tier so we have someone to attempt to negotiate with
+  state.sponsors.push(makeSponsor('sponsor-2', tier));
+
+  installState(state);
 
   console.log(`Title slots allowed:   ${SPONSOR_SLOT_COUNTS[tier]}`);
   console.log(`Active title deals:    ${state.sponsorDeals.filter((d) => d.teamId === teamId && d.tier === tier).length}`);
 
-  // Attempt to start a new negotiation (same logic as game-state-manager.startSponsorNegotiation)
-  const activeDealsForTier = state.sponsorDeals.filter(
-    (d) => d.teamId === teamId && d.tier === tier
-  ).length;
-  const activeNegotiationsForTier = state.negotiations.filter((n) => {
-    if (n.stakeholderType !== StakeholderType.Sponsor) return false;
-    if (n.teamId !== teamId) return false;
-    if (n.phase === NegotiationPhase.Completed || n.phase === NegotiationPhase.Failed) return false;
-    const negSponsor = state.sponsors.find((s) => s.id === (n as SponsorNegotiation).sponsorId);
-    return negSponsor?.tier === tier;
-  }).length;
-  const slotCount = SPONSOR_SLOT_COUNTS[tier];
-  const blocked = activeDealsForTier + activeNegotiationsForTier >= slotCount;
+  const terms: SponsorContractTerms = {
+    signingBonus: 100_000,
+    monthlyPayment: 100_000,
+    duration: 2,
+    placement: SponsorPlacement.Primary,
+  };
 
-  console.log(`Attempt to negotiate: ${blocked ? 'BLOCKED ✓' : 'ALLOWED (unexpected ✗)'}`);
+  let blocked = false;
+  let errorMessage = '';
+  try {
+    GameStateManager.startSponsorNegotiation('sponsor-2', terms);
+  } catch (err) {
+    blocked = true;
+    errorMessage = err instanceof Error ? err.message : String(err);
+  }
+
+  console.log(`Attempt to negotiate: ${blocked ? `BLOCKED ✓ (\"${errorMessage}\")` : 'ALLOWED (unexpected ✗)'}`);
   console.log(`Result: ${blocked ? 'PASS ✓' : 'FAIL ✗'}`);
 }
 

--- a/scripts/sim-sponsors.ts
+++ b/scripts/sim-sponsors.ts
@@ -275,7 +275,7 @@ function scenarioSlots() {
     errorMessage = err instanceof Error ? err.message : String(err);
   }
 
-  console.log(`Attempt to negotiate: ${blocked ? `BLOCKED ✓ (\"${errorMessage}\")` : 'ALLOWED (unexpected ✗)'}`);
+  console.log(`Attempt to negotiate: ${blocked ? `BLOCKED ✓ ("${errorMessage}")` : 'ALLOWED (unexpected ✗)'}`);
   console.log(`Result: ${blocked ? 'PASS ✓' : 'FAIL ✗'}`);
 }
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -281,6 +281,20 @@ export function registerIpcHandlers(): void {
     }
   );
 
+  ipcMain.handle(
+    IpcChannels.SPONSOR_SIGN,
+    (_event, negotiationId: string) => {
+      return GameStateManager.signSponsorDeal(negotiationId);
+    }
+  );
+
+  ipcMain.handle(
+    IpcChannels.SPONSOR_DECLINE,
+    (_event, negotiationId: string) => {
+      return GameStateManager.declineSponsorDeal(negotiationId);
+    }
+  );
+
   // Mail handlers
   ipcMain.handle(IpcChannels.MAIL_MARK_READ, (_event, emailId: string) => {
     return GameStateManager.markEmailRead(emailId);

--- a/src/main/services/contract-creator.ts
+++ b/src/main/services/contract-creator.ts
@@ -491,6 +491,14 @@ export function createSponsorContractFromNegotiation(
   // Add to sponsor deals
   state.sponsorDeals.push(deal);
 
+  // Credit signing bonus to team budget immediately
+  if (terms.signingBonus > 0) {
+    const team = state.teams.find((t) => t.id === negotiation.teamId);
+    if (team) {
+      team.budget += terms.signingBonus;
+    }
+  }
+
   return {
     sponsorId: sponsor.id,
     teamId: negotiation.teamId,
@@ -531,15 +539,35 @@ export function generateSponsorSigningEvent(
     critical: false,
   });
 
-  // Email to player if their team is involved
+  // SPONSOR_SIGNED game event (for Player Wiki / history)
+  state.events.push(
+    createEvent({
+      type: 'SPONSOR_SIGNED',
+      date: { ...state.currentDate },
+      involvedEntities: [teamRef(team.id)],
+      data: {
+        sponsorId: sponsor.id,
+        sponsorName: sponsor.name,
+        teamId: team.id,
+        teamName: team.name,
+        tier: result.tier,
+        monthlyPayment: result.monthlyPayment,
+        signingBonus: result.signingBonus,
+        duration: result.contractDuration,
+      },
+      importance: result.tier === 'title' ? 'high' : 'medium',
+    })
+  );
+
+  // Critical email to player — simulation pauses so player reads the confirmation
   if (isPlayerTeamInvolved) {
     state.calendarEvents.push({
       id: randomUUID(),
       date: state.currentDate,
       type: CalendarEventType.Email,
-      subject: headline,
-      body: `${body} This sponsorship will provide important funding for your team.`,
-      critical: false, // Don't stop sim
+      subject: `${sponsor.name} partnership confirmed`,
+      body: `${sponsor.name} partnership confirmed — ${tierName}, $${result.monthlyPayment.toLocaleString()}/mo, ${result.contractDuration}-year deal. Your signing bonus of $${result.signingBonus.toLocaleString()} has been credited to your team budget.`,
+      critical: true,
     });
   }
 }

--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -88,6 +88,7 @@ import {
   generateBaseContractTerms,
   OFFER_EXPIRY_DAYS,
   LATE_SEASON_MONTH,
+  SPONSOR_SLOT_COUNTS,
 } from '../../shared/domain/engine-utils';
 import { offsetDate } from '../../shared/utils/date-utils';
 
@@ -983,6 +984,22 @@ export const GameStateManager = {
       throw new Error('Sponsor not found');
     }
 
+    // Enforce slot limits: active deals + active negotiations cannot exceed slot count for this tier
+    const activeDealsForTier = state.sponsorDeals.filter(
+      (d) => d.teamId === playerTeamId && d.tier === sponsor.tier
+    ).length;
+    const activeNegotiationsForTier = state.negotiations.filter((n) => {
+      if (n.stakeholderType !== StakeholderType.Sponsor) return false;
+      if (n.teamId !== playerTeamId) return false;
+      if (n.phase === NegotiationPhase.Completed || n.phase === NegotiationPhase.Failed) return false;
+      const negSponsor = state.sponsors.find((s) => s.id === (n as SponsorNegotiation).sponsorId);
+      return negSponsor?.tier === sponsor.tier;
+    }).length;
+    const slotCount = SPONSOR_SLOT_COUNTS[sponsor.tier];
+    if (activeDealsForTier + activeNegotiationsForTier >= slotCount) {
+      throw new Error(`No open ${sponsor.tier} sponsor slots`);
+    }
+
     // Create new negotiation for next season
     const negotiation = createSponsorNegotiation(
       playerTeamId,
@@ -1023,15 +1040,9 @@ export const GameStateManager = {
     }
 
     if (response === 'accept') {
-      // Accept the counterparty's terms - negotiation complete
-      negotiation.phase = NegotiationPhase.Completed;
+      // Counterparty accepted: hold for player confirmation (Sign / Decline)
+      negotiation.phase = NegotiationPhase.PendingPlayerConfirmation;
       negotiation.lastActivityDate = { ...state.currentDate };
-
-      // Create the contract and generate signing event
-      const result = createSponsorContractFromNegotiation(negotiation, state);
-      if (result) {
-        generateSponsorSigningEvent(state, result, true); // Player team is always involved
-      }
     } else if (response === 'reject') {
       // Reject - negotiation failed
       negotiation.phase = NegotiationPhase.Failed;
@@ -1057,6 +1068,63 @@ export const GameStateManager = {
       negotiation.phase = NegotiationPhase.AwaitingResponse;
       negotiation.lastActivityDate = { ...state.currentDate };
     }
+
+    return state;
+  },
+
+  /**
+   * Player confirms a PendingPlayerConfirmation sponsor deal by clicking Sign.
+   * Creates the active deal, credits signing bonus, fires news headline + critical email.
+   */
+  signSponsorDeal(negotiationId: string): GameState {
+    const state = GameStateManager.currentState;
+    if (!state) throw new Error('No game in progress');
+
+    const negotiationIndex = state.negotiations.findIndex((n) => n.id === negotiationId);
+    if (negotiationIndex === -1) throw new Error('Negotiation not found');
+
+    const negotiation = state.negotiations[negotiationIndex] as SponsorNegotiation;
+    if (negotiation.stakeholderType !== StakeholderType.Sponsor) throw new Error('Not a sponsor negotiation');
+    if (negotiation.phase !== NegotiationPhase.PendingPlayerConfirmation) throw new Error('Not pending confirmation');
+
+    // Check slot availability — another Sign earlier this turn may have filled the slot
+    const sponsor = state.sponsors.find((s) => s.id === negotiation.sponsorId);
+    if (!sponsor) throw new Error('Sponsor not found');
+    const filledSlots = state.sponsorDeals.filter(
+      (d) => d.teamId === negotiation.teamId && d.tier === sponsor.tier
+    ).length;
+    if (filledSlots >= SPONSOR_SLOT_COUNTS[sponsor.tier]) {
+      throw new Error(`All ${sponsor.tier} slots are filled`);
+    }
+
+    negotiation.phase = NegotiationPhase.Completed;
+    negotiation.lastActivityDate = { ...state.currentDate };
+
+    const result = createSponsorContractFromNegotiation(negotiation, state);
+    if (result) {
+      generateSponsorSigningEvent(state, result, true);
+    }
+
+    return state;
+  },
+
+  /**
+   * Player declines a PendingPlayerConfirmation sponsor deal.
+   * Marks the negotiation as Failed.
+   */
+  declineSponsorDeal(negotiationId: string): GameState {
+    const state = GameStateManager.currentState;
+    if (!state) throw new Error('No game in progress');
+
+    const negotiationIndex = state.negotiations.findIndex((n) => n.id === negotiationId);
+    if (negotiationIndex === -1) throw new Error('Negotiation not found');
+
+    const negotiation = state.negotiations[negotiationIndex] as SponsorNegotiation;
+    if (negotiation.stakeholderType !== StakeholderType.Sponsor) throw new Error('Not a sponsor negotiation');
+    if (negotiation.phase !== NegotiationPhase.PendingPlayerConfirmation) throw new Error('Not pending confirmation');
+
+    negotiation.phase = NegotiationPhase.Failed;
+    negotiation.lastActivityDate = { ...state.currentDate };
 
     return state;
   },

--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -1040,9 +1040,16 @@ export const GameStateManager = {
     }
 
     if (response === 'accept') {
-      // Counterparty accepted: hold for player confirmation (Sign / Decline)
-      negotiation.phase = NegotiationPhase.PendingPlayerConfirmation;
+      // Player explicitly accepted the counterparty's terms — complete immediately.
+      // The PendingPlayerConfirmation gate only applies to engine-driven completions
+      // (when a sponsor accepts the player's offer without further player action).
+      negotiation.phase = NegotiationPhase.Completed;
       negotiation.lastActivityDate = { ...state.currentDate };
+
+      const result = createSponsorContractFromNegotiation(negotiation, state);
+      if (result) {
+        generateSponsorSigningEvent(state, result, true);
+      }
     } else if (response === 'reject') {
       // Reject - negotiation failed
       negotiation.phase = NegotiationPhase.Failed;

--- a/src/main/services/negotiation-processor.ts
+++ b/src/main/services/negotiation-processor.ts
@@ -220,19 +220,27 @@ export function applyNegotiationUpdates(state: GameState, updates: NegotiationUp
         // Sponsor negotiation
         const sponsorNeg = negotiation as SponsorNegotiation;
 
-        // Handle completed negotiations - create sponsor deals for ALL teams
+        // When the engine accepts a sponsor deal, gate it behind player confirmation
+        // instead of auto-creating the contract. AI team deals complete immediately.
         if (sponsorNeg.phase === NegotiationPhase.Completed) {
-          const contractResult = createSponsorContractFromNegotiation(sponsorNeg, state);
-          if (contractResult) {
-            generateSponsorSigningEvent(state, contractResult, isPlayerTeam);
+          if (isPlayerTeam) {
+            // Intercept: hold at PendingPlayerConfirmation until player clicks Sign
+            sponsorNeg.phase = NegotiationPhase.PendingPlayerConfirmation;
+            state.negotiations[index] = sponsorNeg;
+            shouldStop = true;
+          } else {
+            // AI teams: create the deal directly
+            const contractResult = createSponsorContractFromNegotiation(sponsorNeg, state);
+            if (contractResult) {
+              generateSponsorSigningEvent(state, contractResult, false);
+            }
           }
         }
 
-        // Check if this affects player and should stop simulation
-        if (update.shouldStopSimulation && isPlayerTeam) {
+        // For non-completed player-team updates that require attention (counter, reject)
+        if (update.shouldStopSimulation && isPlayerTeam && sponsorNeg.phase !== NegotiationPhase.PendingPlayerConfirmation) {
           shouldStop = true;
 
-          // Generate email for player
           const sponsor = state.sponsors.find((s) => s.id === sponsorNeg.sponsorId);
           if (sponsor) {
             const latestRound = sponsorNeg.rounds[sponsorNeg.rounds.length - 1];

--- a/src/main/services/sponsor-mechanics.ts
+++ b/src/main/services/sponsor-mechanics.ts
@@ -1,0 +1,14 @@
+import type { GameState } from '../../shared/domain/types';
+
+/**
+ * Credit monthly sponsor payments to each team's budget.
+ * Called once at the start of each new month in the turn loop.
+ */
+export function applyMonthlyIncomeTick(state: GameState): void {
+  for (const deal of state.sponsorDeals) {
+    const team = state.teams.find((t) => t.id === deal.teamId);
+    if (team && deal.monthlyPayment > 0) {
+      team.budget += deal.monthlyPayment;
+    }
+  }
+}

--- a/src/main/services/sponsor-mechanics.ts
+++ b/src/main/services/sponsor-mechanics.ts
@@ -3,11 +3,20 @@ import type { GameState } from '../../shared/domain/types';
 /**
  * Credit monthly sponsor payments to each team's budget.
  * Called once at the start of each new month in the turn loop.
+ *
+ * Only deals whose contract is active for the current season pay out — i.e.
+ * `startSeason <= currentSeason <= endSeason`. Deals signed in season N for
+ * season N+1 do not pay during N, and deals whose endSeason has passed do not
+ * keep paying after the contract ends.
  */
 export function applyMonthlyIncomeTick(state: GameState): void {
+  const currentSeason = state.currentSeason.seasonNumber;
   for (const deal of state.sponsorDeals) {
+    if (deal.startSeason > currentSeason) continue;
+    if (deal.endSeason < currentSeason) continue;
+    if (deal.monthlyPayment <= 0) continue;
     const team = state.teams.find((t) => t.id === deal.teamId);
-    if (team && deal.monthlyPayment > 0) {
+    if (team) {
       team.budget += deal.monthlyPayment;
     }
   }

--- a/src/main/services/turn-processor.ts
+++ b/src/main/services/turn-processor.ts
@@ -283,7 +283,6 @@ export function processSpecReleases(state: GameState, currentDate: GameDate): vo
 // TURN RESULT APPLICATION
 // =============================================================================
 
-
 /**
  * Apply turn processing result to game state (mutates state)
  * Returns true if player team had a design milestone or test completion (for auto-stop)

--- a/src/main/services/turn-processor.ts
+++ b/src/main/services/turn-processor.ts
@@ -54,6 +54,7 @@ import {
   ENGINE_STAT_DISPLAY_NAMES,
 } from '../../shared/domain/engine-utils';
 import { generateDailyNews, pushNewsEvent } from './news-generator';
+import { applyMonthlyIncomeTick } from './sponsor-mechanics';
 
 /** Shared engine manager instance */
 const engineManager = new EngineManager();
@@ -282,18 +283,6 @@ export function processSpecReleases(state: GameState, currentDate: GameDate): vo
 // TURN RESULT APPLICATION
 // =============================================================================
 
-/**
- * Credit monthly sponsor payments to each team's budget.
- * Runs once on the first day of each month.
- */
-function applyMonthlyIncomeTick(state: GameState): void {
-  for (const deal of state.sponsorDeals) {
-    const team = state.teams.find((t) => t.id === deal.teamId);
-    if (team && deal.monthlyPayment > 0) {
-      team.budget += deal.monthlyPayment;
-    }
-  }
-}
 
 /**
  * Apply turn processing result to game state (mutates state)

--- a/src/main/services/turn-processor.ts
+++ b/src/main/services/turn-processor.ts
@@ -283,12 +283,31 @@ export function processSpecReleases(state: GameState, currentDate: GameDate): vo
 // =============================================================================
 
 /**
+ * Credit monthly sponsor payments to each team's budget.
+ * Runs once on the first day of each month.
+ */
+function applyMonthlyIncomeTick(state: GameState): void {
+  for (const deal of state.sponsorDeals) {
+    const team = state.teams.find((t) => t.id === deal.teamId);
+    if (team && deal.monthlyPayment > 0) {
+      team.budget += deal.monthlyPayment;
+    }
+  }
+}
+
+/**
  * Apply turn processing result to game state (mutates state)
  * Returns true if player team had a design milestone or test completion (for auto-stop)
  */
 export function applyTurnResult(state: GameState, result: TurnProcessingResult): boolean {
+  const prevDate = state.currentDate;
   state.currentDate = result.newDate;
   state.phase = result.newPhase;
+
+  // Fire monthly income tick on the first day of each new month
+  if (result.newDate.day === 1 && result.newDate.month !== prevDate.month) {
+    applyMonthlyIncomeTick(state);
+  }
   applyDriverStateChanges(state, result.driverStateChanges);
   applyTeamStateChanges(state, result.teamStateChanges);
 

--- a/src/renderer/content/Deals.tsx
+++ b/src/renderer/content/Deals.tsx
@@ -49,23 +49,23 @@ const DURATION_OPTIONS: DropdownOption<DurationValue>[] = [
   { value: '3', label: '3 Years' },
 ];
 
-/** Industry icons */
+/** Industry icons (matches Sponsors.tsx) */
 const INDUSTRY_ICONS: Record<string, string> = {
-  'oil-gas': '⛽',
+  'oil-gas': '\u26FD',
   technology: '\u{1F4BB}',
   finance: '\u{1F4B3}',
   telecommunications: '\u{1F4F1}',
   payments: '\u{1F4B8}',
   'water-technology': '\u{1F4A7}',
   consulting: '\u{1F4BC}',
-  aviation: '✈️',
+  aviation: '\u2708\uFE0F',
   luxury: '\u{1F48E}',
   beverages: '\u{1F37A}',
   logistics: '\u{1F4E6}',
   apparel: '\u{1F455}',
-  insurance: '\u{1F6E1}️',
+  insurance: '\u{1F6E1}\uFE0F',
   tyres: '\u{1F6DE}',
-  components: '⚙️',
+  components: '\u2699\uFE0F',
   'consumer-electronics': '\u{1F4F7}',
   entertainment: '\u{1F3AC}',
   hospitality: '\u{1F3E8}',
@@ -281,14 +281,14 @@ function ContactModal({ sponsor, currentSeason, onClose, onSubmit }: ContactModa
 interface NegotiationCardProps {
   negotiation: SponsorNegotiation;
   sponsor: Sponsor;
-  isSlotFilled: boolean;
-  onAccept: () => void;
-  onReject: () => void;
-  onSign: () => void;
-  onDecline: () => void;
+  isSlotFilled?: boolean;
+  onAccept?: () => void;
+  onReject?: () => void;
+  onSign?: () => void;
+  onDecline?: () => void;
 }
 
-function NegotiationCard({ negotiation, sponsor, isSlotFilled, onAccept, onReject, onSign, onDecline }: NegotiationCardProps) {
+function NegotiationCard({ negotiation, sponsor, isSlotFilled = false, onAccept, onReject, onSign, onDecline }: NegotiationCardProps) {
   const lastRound = negotiation.rounds[negotiation.rounds.length - 1];
   const terms = lastRound?.terms as SponsorContractTerms | undefined;
   const isResponseReceived = negotiation.phase === NegotiationPhase.ResponseReceived;
@@ -462,11 +462,9 @@ interface DealsProps {
   embedded?: boolean;
   /** Initial tier filter to apply (e.g., when navigating from an empty sponsor slot) */
   initialTierFilter?: SponsorTier;
-  /** Called when the "needs your attention" count changes, so parent can update badge */
-  onNeedsAttentionCountChange?: (count: number) => void;
 }
 
-export function Deals({ embedded = false, initialTierFilter, onNeedsAttentionCountChange }: DealsProps) {
+export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
   const [activeTab, setActiveTab] = useState<DealsTab>('browse');
   const [tierFilter, setTierFilter] = useState<TierFilter>(initialTierFilter ?? 'all');
   const [contactingSponsor, setContactingSponsor] = useState<Sponsor | null>(null);
@@ -556,11 +554,6 @@ export function Deals({ embedded = false, initialTierFilter, onNeedsAttentionCou
     }
     return result;
   }, [gameState]);
-
-  // Notify parent of "needs attention" count changes
-  useEffect(() => {
-    onNeedsAttentionCountChange?.(needsAttention.length);
-  }, [needsAttention.length, onNeedsAttentionCountChange]);
 
   // Filter sponsors for browse tab
   const filteredSponsors = useMemo(() => {
@@ -660,7 +653,7 @@ export function Deals({ embedded = false, initialTierFilter, onNeedsAttentionCou
         <div className="space-y-4">
           <div className="card p-4" style={ACCENT_CARD_STYLE}>
             <div className="flex items-start gap-3">
-              <div className="text-blue-400 text-xl">ℹ️</div>
+              <div className="text-blue-400 text-xl">ℹ\uFE0F</div>
               <div>
                 <h3 className="text-sm font-semibold text-primary mb-1">
                   Sponsor Negotiations
@@ -734,7 +727,7 @@ export function Deals({ embedded = false, initialTierFilter, onNeedsAttentionCou
             </div>
           )}
 
-          {/* Sent */}
+          {/* Sent — AwaitingResponse only; no actionable buttons render */}
           <SectionHeader title="Sent" count={sentNegotiations.length} />
           {sentNegotiations.length === 0 ? (
             <p className="text-sm text-muted px-1 pb-2">No proposals awaiting a response.</p>
@@ -748,11 +741,6 @@ export function Deals({ embedded = false, initialTierFilter, onNeedsAttentionCou
                     key={negotiation.id}
                     negotiation={negotiation}
                     sponsor={sponsor}
-                    isSlotFilled={false}
-                    onAccept={() => handleRespondToOffer(negotiation.id, 'accept')}
-                    onReject={() => handleRespondToOffer(negotiation.id, 'reject')}
-                    onSign={() => handleSign(negotiation.id)}
-                    onDecline={() => handleDecline(negotiation.id)}
                   />
                 );
               })}
@@ -780,11 +768,6 @@ export function Deals({ embedded = false, initialTierFilter, onNeedsAttentionCou
                       key={negotiation.id}
                       negotiation={negotiation}
                       sponsor={sponsor}
-                      isSlotFilled={false}
-                      onAccept={() => handleRespondToOffer(negotiation.id, 'accept')}
-                      onReject={() => handleRespondToOffer(negotiation.id, 'reject')}
-                      onSign={() => handleSign(negotiation.id)}
-                      onDecline={() => handleDecline(negotiation.id)}
                     />
                   );
                 })

--- a/src/renderer/content/Deals.tsx
+++ b/src/renderer/content/Deals.tsx
@@ -637,6 +637,7 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
   }
 
   const currentSeason = gameState.currentSeason.seasonNumber;
+  const badgeCount = needsAttention.length + sentNegotiations.length;
 
   return (
     <div className="space-y-4">
@@ -646,7 +647,7 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
         tabs={TABS}
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        badge={needsAttention.length + sentNegotiations.length > 0 ? { tabId: 'negotiations', count: needsAttention.length + sentNegotiations.length } : undefined}
+        badge={badgeCount > 0 ? { tabId: 'negotiations', count: badgeCount } : undefined}
       />
 
       {activeTab === 'browse' && (

--- a/src/renderer/content/Deals.tsx
+++ b/src/renderer/content/Deals.tsx
@@ -653,7 +653,7 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
         <div className="space-y-4">
           <div className="card p-4" style={ACCENT_CARD_STYLE}>
             <div className="flex items-start gap-3">
-              <div className="text-blue-400 text-xl">ℹ\uFE0F</div>
+              <div className="text-blue-400 text-xl">{'ℹ️'}</div>
               <div>
                 <h3 className="text-sm font-semibold text-primary mb-1">
                   Sponsor Negotiations

--- a/src/renderer/content/Deals.tsx
+++ b/src/renderer/content/Deals.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { useDerivedGameState, queryKeys } from '../hooks';
 import { useQueryClient } from '@tanstack/react-query';
 import { SectionHeading, TabBar, Dropdown } from '../components';
@@ -16,6 +16,7 @@ import {
   type SponsorNegotiation,
   type SponsorContractTerms,
 } from '../../shared/domain';
+import { SPONSOR_SLOT_COUNTS } from '../../shared/domain/engine-utils';
 
 // ===========================================
 // TYPES
@@ -50,21 +51,21 @@ const DURATION_OPTIONS: DropdownOption<DurationValue>[] = [
 
 /** Industry icons */
 const INDUSTRY_ICONS: Record<string, string> = {
-  'oil-gas': '\u26FD',
+  'oil-gas': '⛽',
   technology: '\u{1F4BB}',
   finance: '\u{1F4B3}',
   telecommunications: '\u{1F4F1}',
   payments: '\u{1F4B8}',
   'water-technology': '\u{1F4A7}',
   consulting: '\u{1F4BC}',
-  aviation: '\u2708\uFE0F',
+  aviation: '✈️',
   luxury: '\u{1F48E}',
   beverages: '\u{1F37A}',
   logistics: '\u{1F4E6}',
   apparel: '\u{1F455}',
-  insurance: '\u{1F6E1}\uFE0F',
+  insurance: '\u{1F6E1}️',
   tyres: '\u{1F6DE}',
-  components: '\u2699\uFE0F',
+  components: '⚙️',
   'consumer-electronics': '\u{1F4F7}',
   entertainment: '\u{1F3AC}',
   hospitality: '\u{1F3E8}',
@@ -93,19 +94,6 @@ function getPlacementForTier(tier: SponsorTier): SponsorPlacement {
     case SponsorTier.Minor:
     default:
       return SponsorPlacement.Tertiary;
-  }
-}
-
-function getPhaseLabel(phase: NegotiationPhase): string {
-  switch (phase) {
-    case NegotiationPhase.AwaitingResponse:
-      return 'Awaiting Response';
-    case NegotiationPhase.ResponseReceived:
-      return 'Response Received';
-    case NegotiationPhase.Completed:
-      return 'Completed';
-    case NegotiationPhase.Failed:
-      return 'Failed';
   }
 }
 
@@ -147,10 +135,27 @@ interface SponsorCardProps {
   sponsor: Sponsor;
   isContracted: boolean;
   isNegotiating: boolean;
+  isSlotFull: boolean;
   onContact: () => void;
 }
 
-function SponsorCard({ sponsor, isContracted, isNegotiating, onContact }: SponsorCardProps) {
+function SponsorCard({ sponsor, isContracted, isNegotiating, isSlotFull, onContact }: SponsorCardProps) {
+  const renderCTA = () => {
+    if (isContracted) return <span className="text-sm text-emerald-400">Contracted</span>;
+    if (isNegotiating) return <span className="text-sm text-amber-400">Negotiating</span>;
+    if (isSlotFull) return <span className="text-sm text-neutral-500">Slot full.</span>;
+    return (
+      <button
+        type="button"
+        onClick={onContact}
+        className="btn cursor-pointer px-4 py-2 text-sm font-medium"
+        style={ACCENT_BORDERED_BUTTON_STYLE}
+      >
+        Contact
+      </button>
+    );
+  };
+
   return (
     <div className="card p-4 flex items-center gap-4" style={ACCENT_CARD_STYLE}>
       <SponsorLogo sponsor={sponsor} size="md" />
@@ -169,20 +174,7 @@ function SponsorCard({ sponsor, isContracted, isNegotiating, onContact }: Sponso
       </div>
 
       <div className="flex-shrink-0">
-        {isContracted ? (
-          <span className="text-sm text-emerald-400">Contracted</span>
-        ) : isNegotiating ? (
-          <span className="text-sm text-amber-400">Negotiating</span>
-        ) : (
-          <button
-            type="button"
-            onClick={onContact}
-            className="btn cursor-pointer px-4 py-2 text-sm font-medium"
-            style={ACCENT_BORDERED_BUTTON_STYLE}
-          >
-            Contact
-          </button>
-        )}
+        {renderCTA()}
       </div>
     </div>
   );
@@ -289,14 +281,18 @@ function ContactModal({ sponsor, currentSeason, onClose, onSubmit }: ContactModa
 interface NegotiationCardProps {
   negotiation: SponsorNegotiation;
   sponsor: Sponsor;
+  isSlotFilled: boolean;
   onAccept: () => void;
   onReject: () => void;
+  onSign: () => void;
+  onDecline: () => void;
 }
 
-function NegotiationCard({ negotiation, sponsor, onAccept, onReject }: NegotiationCardProps) {
+function NegotiationCard({ negotiation, sponsor, isSlotFilled, onAccept, onReject, onSign, onDecline }: NegotiationCardProps) {
   const lastRound = negotiation.rounds[negotiation.rounds.length - 1];
   const terms = lastRound?.terms as SponsorContractTerms | undefined;
-  const isPlayerTurn = negotiation.phase === NegotiationPhase.ResponseReceived;
+  const isResponseReceived = negotiation.phase === NegotiationPhase.ResponseReceived;
+  const isPendingConfirmation = negotiation.phase === NegotiationPhase.PendingPlayerConfirmation;
   const isComplete = negotiation.phase === NegotiationPhase.Completed;
   const isFailed = negotiation.phase === NegotiationPhase.Failed;
 
@@ -321,10 +317,14 @@ function NegotiationCard({ negotiation, sponsor, onAccept, onReject }: Negotiati
             <span className={
               isComplete ? 'text-emerald-400' :
               isFailed ? 'text-red-400' :
-              isPlayerTurn ? 'text-amber-400' :
+              isResponseReceived || isPendingConfirmation ? 'text-amber-400' :
               'text-blue-400'
             }>
-              {getPhaseLabel(negotiation.phase)}
+              {isPendingConfirmation ? 'Accepted — awaiting your signature' :
+               isComplete ? 'Completed' :
+               isFailed ? 'Failed' :
+               isResponseReceived ? 'Response Received' :
+               'Awaiting Response'}
             </span>
             <span className="text-muted">•</span>
             <span className="text-muted">Round {negotiation.currentRound}</span>
@@ -335,7 +335,8 @@ function NegotiationCard({ negotiation, sponsor, onAccept, onReject }: Negotiati
       {terms && !isComplete && !isFailed && (
         <div className="mt-4 pt-4 border-t border-neutral-700">
           <h4 className="text-sm font-medium text-secondary mb-2">
-            {lastRound?.offeredBy === 'player' ? 'Your Offer' : 'Their Offer'}
+            {isPendingConfirmation ? 'Accepted Terms' :
+             lastRound?.offeredBy === 'player' ? 'Your Offer' : 'Their Offer'}
           </h4>
           <div className="grid grid-cols-3 gap-4 text-sm">
             <div>
@@ -354,7 +355,7 @@ function NegotiationCard({ negotiation, sponsor, onAccept, onReject }: Negotiati
         </div>
       )}
 
-      {isPlayerTurn && (
+      {isResponseReceived && (
         <div className="flex gap-3 mt-4">
           <button
             type="button"
@@ -370,6 +371,28 @@ function NegotiationCard({ negotiation, sponsor, onAccept, onReject }: Negotiati
             style={ACCENT_BORDERED_BUTTON_STYLE}
           >
             Accept
+          </button>
+        </div>
+      )}
+
+      {isPendingConfirmation && (
+        <div className="flex gap-3 mt-4">
+          <button
+            type="button"
+            onClick={onDecline}
+            className={`btn cursor-pointer flex-1 px-4 py-2 ${GHOST_BORDERED_BUTTON_CLASSES}`}
+          >
+            Decline
+          </button>
+          <button
+            type="button"
+            onClick={onSign}
+            disabled={isSlotFilled}
+            className={`btn cursor-pointer flex-1 px-4 py-2 font-medium ${isSlotFilled ? 'opacity-50 cursor-not-allowed' : ''}`}
+            style={isSlotFilled ? undefined : ACCENT_BORDERED_BUTTON_STYLE}
+            title={isSlotFilled ? 'Slot filled by another deal' : undefined}
+          >
+            {isSlotFilled ? 'Slot filled.' : 'Sign'}
           </button>
         </div>
       )}
@@ -393,6 +416,43 @@ function NegotiationCard({ negotiation, sponsor, onAccept, onReject }: Negotiati
   );
 }
 
+interface SectionHeaderProps {
+  title: string;
+  count?: number;
+  collapsible?: boolean;
+  collapsed?: boolean;
+  onToggle?: () => void;
+}
+
+function SectionHeader({ title, count, collapsible, collapsed, onToggle }: SectionHeaderProps) {
+  return (
+    <div
+      className={`flex items-center gap-2 py-2 ${collapsible ? 'cursor-pointer select-none' : ''}`}
+      onClick={collapsible ? onToggle : undefined}
+    >
+      <span className="text-sm font-semibold text-secondary uppercase tracking-wide">{title}</span>
+      {count !== undefined && count > 0 && (
+        <span className="text-xs px-1.5 py-0.5 rounded-full bg-amber-500 text-black font-bold">{count}</span>
+      )}
+      {collapsible && (
+        <span className="text-muted text-xs ml-auto">{collapsed ? '▶' : '▼'}</span>
+      )}
+    </div>
+  );
+}
+
+interface ToastProps {
+  message: string;
+}
+
+function Toast({ message }: ToastProps) {
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-2 bg-neutral-800 border border-neutral-600 rounded-lg shadow-lg text-sm text-primary pointer-events-none">
+      {message}
+    </div>
+  );
+}
+
 // ===========================================
 // MAIN COMPONENT
 // ===========================================
@@ -402,14 +462,18 @@ interface DealsProps {
   embedded?: boolean;
   /** Initial tier filter to apply (e.g., when navigating from an empty sponsor slot) */
   initialTierFilter?: SponsorTier;
+  /** Called when the "needs your attention" count changes, so parent can update badge */
+  onNeedsAttentionCountChange?: (count: number) => void;
 }
 
-export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
+export function Deals({ embedded = false, initialTierFilter, onNeedsAttentionCountChange }: DealsProps) {
   const [activeTab, setActiveTab] = useState<DealsTab>('browse');
   const [tierFilter, setTierFilter] = useState<TierFilter>(initialTierFilter ?? 'all');
   const [contactingSponsor, setContactingSponsor] = useState<Sponsor | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [historyCollapsed, setHistoryCollapsed] = useState(true);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Sync tier filter when initialTierFilter prop changes (e.g., clicking a different empty slot)
   useEffect(() => {
     if (initialTierFilter) {
       setTierFilter(initialTierFilter);
@@ -423,6 +487,18 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
     queryClient.invalidateQueries({ queryKey: queryKeys.gameState });
   }, [queryClient]);
 
+  const showToast = useCallback((msg: string) => {
+    setToastMessage(msg);
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => setToastMessage(null), 3000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    };
+  }, []);
+
   // Get player's current sponsor deals
   const playerDeals = useMemo(() => {
     if (!gameState) return new Set<string>();
@@ -433,8 +509,8 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
     );
   }, [gameState]);
 
-  // Get player's active sponsor negotiations
-  const activeNegotiations = useMemo(() => {
+  // All player sponsor negotiations
+  const allNegotiations = useMemo(() => {
     if (!gameState) return [];
     return gameState.negotiations.filter(
       (n): n is SponsorNegotiation =>
@@ -443,13 +519,48 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
     );
   }, [gameState]);
 
+  // Inbox sections
+  const needsAttention = useMemo(() =>
+    allNegotiations.filter(
+      (n) => n.phase === NegotiationPhase.ResponseReceived || n.phase === NegotiationPhase.PendingPlayerConfirmation
+    ), [allNegotiations]);
+
+  const sentNegotiations = useMemo(() =>
+    allNegotiations.filter((n) => n.phase === NegotiationPhase.AwaitingResponse),
+    [allNegotiations]);
+
+  const historyNegotiations = useMemo(() =>
+    allNegotiations.filter(
+      (n) => n.phase === NegotiationPhase.Failed || n.phase === NegotiationPhase.Completed
+    ), [allNegotiations]);
+
+  // Active (non-terminal) negotiations for browse-tab state
   const negotiatingSponsorIds = useMemo(() => {
     return new Set(
-      activeNegotiations
+      allNegotiations
         .filter((n) => n.phase !== NegotiationPhase.Completed && n.phase !== NegotiationPhase.Failed)
         .map((n) => n.sponsorId)
     );
-  }, [activeNegotiations]);
+  }, [allNegotiations]);
+
+  // Slot fullness per tier (active deals count)
+  const tierSlotsFull = useMemo(() => {
+    if (!gameState) return {} as Record<SponsorTier, boolean>;
+    const playerTeamId = gameState.player.teamId;
+    const result = {} as Record<SponsorTier, boolean>;
+    for (const tier of Object.values(SponsorTier)) {
+      const dealCount = gameState.sponsorDeals.filter(
+        (d) => d.teamId === playerTeamId && d.tier === tier
+      ).length;
+      result[tier] = dealCount >= SPONSOR_SLOT_COUNTS[tier];
+    }
+    return result;
+  }, [gameState]);
+
+  // Notify parent of "needs attention" count changes
+  useEffect(() => {
+    onNeedsAttentionCountChange?.(needsAttention.length);
+  }, [needsAttention.length, onNeedsAttentionCountChange]);
 
   // Filter sponsors for browse tab
   const filteredSponsors = useMemo(() => {
@@ -458,7 +569,6 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
     if (tierFilter !== 'all') {
       sponsors = sponsors.filter((s) => s.tier === tierFilter);
     }
-    // Sort by tier (Title > Major > Minor), then by base payment
     const tierOrder = { [SponsorTier.Title]: 0, [SponsorTier.Major]: 1, [SponsorTier.Minor]: 2 };
     return [...sponsors].sort((a, b) => {
       const tierDiff = tierOrder[a.tier] - tierOrder[b.tier];
@@ -470,6 +580,7 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
   // Handlers
   const handleStartNegotiation = useCallback(async (terms: SponsorContractTerms) => {
     if (!contactingSponsor) return;
+    const sponsorName = contactingSponsor.name;
     try {
       await window.electronAPI.invoke(IpcChannels.SPONSOR_START_NEGOTIATION, {
         sponsorId: contactingSponsor.id,
@@ -477,11 +588,12 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
       });
       refreshGameState();
       setContactingSponsor(null);
-      setActiveTab('negotiations');
+      // Stay on Browse tab; show toast; badge auto-updates via needsAttention
+      showToast(`Proposal sent to ${sponsorName}.`);
     } catch (error) {
       console.error('Failed to start negotiation:', error);
     }
-  }, [contactingSponsor, refreshGameState]);
+  }, [contactingSponsor, refreshGameState, showToast]);
 
   const handleRespondToOffer = useCallback(async (negotiationId: string, response: 'accept' | 'reject') => {
     try {
@@ -495,10 +607,28 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
     }
   }, [refreshGameState]);
 
+  const handleSign = useCallback(async (negotiationId: string) => {
+    try {
+      await window.electronAPI.invoke(IpcChannels.SPONSOR_SIGN, negotiationId);
+      refreshGameState();
+    } catch (error) {
+      console.error('Failed to sign deal:', error);
+    }
+  }, [refreshGameState]);
+
+  const handleDecline = useCallback(async (negotiationId: string) => {
+    try {
+      await window.electronAPI.invoke(IpcChannels.SPONSOR_DECLINE, negotiationId);
+      refreshGameState();
+    } catch (error) {
+      console.error('Failed to decline deal:', error);
+    }
+  }, [refreshGameState]);
+
   if (isLoading) {
     return (
       <div className="p-4">
-        <SectionHeading>Deals</SectionHeading>
+        {!embedded && <SectionHeading>Deals</SectionHeading>}
         <p className="text-muted">Loading...</p>
       </div>
     );
@@ -507,16 +637,13 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
   if (!gameState) {
     return (
       <div className="p-4">
-        <SectionHeading>Deals</SectionHeading>
+        {!embedded && <SectionHeading>Deals</SectionHeading>}
         <p className="text-muted">No game data available.</p>
       </div>
     );
   }
 
   const currentSeason = gameState.currentSeason.seasonNumber;
-  const pendingNegotiations = activeNegotiations.filter(
-    (n) => n.phase === NegotiationPhase.ResponseReceived
-  );
 
   return (
     <div className="space-y-4">
@@ -526,12 +653,11 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
         tabs={TABS}
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        badge={pendingNegotiations.length > 0 ? { tabId: 'negotiations', count: pendingNegotiations.length } : undefined}
+        badge={needsAttention.length > 0 ? { tabId: 'negotiations', count: needsAttention.length } : undefined}
       />
 
       {activeTab === 'browse' && (
         <div className="space-y-4">
-          {/* Info banner */}
           <div className="card p-4" style={ACCENT_CARD_STYLE}>
             <div className="flex items-start gap-3">
               <div className="text-blue-400 text-xl">ℹ️</div>
@@ -547,7 +673,6 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
             </div>
           </div>
 
-          {/* Filter */}
           <div className="flex items-center gap-4">
             <span className="text-sm text-secondary">Filter by tier:</span>
             <div className="w-40">
@@ -559,7 +684,6 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
             </div>
           </div>
 
-          {/* Sponsor list */}
           <div className="space-y-3">
             {filteredSponsors.map((sponsor) => (
               <SponsorCard
@@ -567,6 +691,7 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
                 sponsor={sponsor}
                 isContracted={playerDeals.has(sponsor.id)}
                 isNegotiating={negotiatingSponsorIds.has(sponsor.id)}
+                isSlotFull={!playerDeals.has(sponsor.id) && !negotiatingSponsorIds.has(sponsor.id) && tierSlotsFull[sponsor.tier]}
                 onContact={() => setContactingSponsor(sponsor)}
               />
             ))}
@@ -580,17 +705,42 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
       )}
 
       {activeTab === 'negotiations' && (
-        <div className="space-y-4">
-          {activeNegotiations.length === 0 ? (
-            <div className="card p-8 text-center" style={ACCENT_CARD_STYLE}>
-              <p className="text-muted mb-2">No active negotiations.</p>
-              <p className="text-sm text-secondary">
-                Browse sponsors to start a negotiation.
-              </p>
-            </div>
+        <div className="space-y-2">
+          {/* Needs Your Attention */}
+          <SectionHeader title="Needs your attention" count={needsAttention.length} />
+          {needsAttention.length === 0 ? (
+            <p className="text-sm text-muted px-1 pb-2">Nothing needs your attention right now.</p>
           ) : (
-            <div className="space-y-3">
-              {activeNegotiations.map((negotiation) => {
+            <div className="space-y-3 pb-2">
+              {needsAttention.map((negotiation) => {
+                const sponsor = gameState.sponsors.find((s) => s.id === negotiation.sponsorId);
+                if (!sponsor) return null;
+                const slotFilled = negotiation.phase === NegotiationPhase.PendingPlayerConfirmation
+                  ? tierSlotsFull[sponsor.tier]
+                  : false;
+                return (
+                  <NegotiationCard
+                    key={negotiation.id}
+                    negotiation={negotiation}
+                    sponsor={sponsor}
+                    isSlotFilled={slotFilled}
+                    onAccept={() => handleRespondToOffer(negotiation.id, 'accept')}
+                    onReject={() => handleRespondToOffer(negotiation.id, 'reject')}
+                    onSign={() => handleSign(negotiation.id)}
+                    onDecline={() => handleDecline(negotiation.id)}
+                  />
+                );
+              })}
+            </div>
+          )}
+
+          {/* Sent */}
+          <SectionHeader title="Sent" count={sentNegotiations.length} />
+          {sentNegotiations.length === 0 ? (
+            <p className="text-sm text-muted px-1 pb-2">No proposals awaiting a response.</p>
+          ) : (
+            <div className="space-y-3 pb-2">
+              {sentNegotiations.map((negotiation) => {
                 const sponsor = gameState.sponsors.find((s) => s.id === negotiation.sponsorId);
                 if (!sponsor) return null;
                 return (
@@ -598,11 +748,47 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
                     key={negotiation.id}
                     negotiation={negotiation}
                     sponsor={sponsor}
+                    isSlotFilled={false}
                     onAccept={() => handleRespondToOffer(negotiation.id, 'accept')}
                     onReject={() => handleRespondToOffer(negotiation.id, 'reject')}
+                    onSign={() => handleSign(negotiation.id)}
+                    onDecline={() => handleDecline(negotiation.id)}
                   />
                 );
               })}
+            </div>
+          )}
+
+          {/* History — collapsed by default */}
+          <SectionHeader
+            title="History"
+            count={historyNegotiations.length}
+            collapsible
+            collapsed={historyCollapsed}
+            onToggle={() => setHistoryCollapsed((c) => !c)}
+          />
+          {!historyCollapsed && (
+            <div className="space-y-3 pb-2">
+              {historyNegotiations.length === 0 ? (
+                <p className="text-sm text-muted px-1">No history yet.</p>
+              ) : (
+                historyNegotiations.map((negotiation) => {
+                  const sponsor = gameState.sponsors.find((s) => s.id === negotiation.sponsorId);
+                  if (!sponsor) return null;
+                  return (
+                    <NegotiationCard
+                      key={negotiation.id}
+                      negotiation={negotiation}
+                      sponsor={sponsor}
+                      isSlotFilled={false}
+                      onAccept={() => handleRespondToOffer(negotiation.id, 'accept')}
+                      onReject={() => handleRespondToOffer(negotiation.id, 'reject')}
+                      onSign={() => handleSign(negotiation.id)}
+                      onDecline={() => handleDecline(negotiation.id)}
+                    />
+                  );
+                })
+              )}
             </div>
           )}
         </div>
@@ -617,6 +803,9 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
           onSubmit={handleStartNegotiation}
         />
       )}
+
+      {/* Bottom-centre toast */}
+      {toastMessage && <Toast message={toastMessage} />}
     </div>
   );
 }

--- a/src/renderer/content/Deals.tsx
+++ b/src/renderer/content/Deals.tsx
@@ -646,7 +646,7 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
         tabs={TABS}
         activeTab={activeTab}
         onTabChange={setActiveTab}
-        badge={needsAttention.length > 0 ? { tabId: 'negotiations', count: needsAttention.length } : undefined}
+        badge={needsAttention.length + sentNegotiations.length > 0 ? { tabId: 'negotiations', count: needsAttention.length + sentNegotiations.length } : undefined}
       />
 
       {activeTab === 'browse' && (

--- a/src/renderer/content/Finance.tsx
+++ b/src/renderer/content/Finance.tsx
@@ -109,7 +109,7 @@ function IncomeSection({ deals, sponsors, totalIncome }: IncomeSectionProps) {
 
   return (
     <section>
-      <SectionHeading>Annual Income</SectionHeading>
+      <SectionHeading>Monthly Sponsor Income</SectionHeading>
       <div className="card p-5">
         {deals.length === 0 ? (
           <EmptyState message="No sponsor deals" />
@@ -122,13 +122,13 @@ function IncomeSection({ deals, sponsors, totalIncome }: IncomeSectionProps) {
                   key={deal.sponsorId}
                   label={sponsor?.name ?? deal.sponsorId}
                   sublabel={SPONSOR_TIER_LABELS[deal.tier]}
-                  amount={deal.monthlyPayment * 12}
+                  amount={deal.monthlyPayment}
                 />
               );
             })}
           </div>
         )}
-        <TotalRow label="Total Income" amount={totalIncome} />
+        <TotalRow label="Total Monthly" amount={totalIncome} />
       </div>
     </section>
   );
@@ -231,13 +231,15 @@ export function Finance() {
     (c) => c.teamId === playerTeam.id && c.annualCost > 0
   );
 
-  // Calculate totals (single source of truth)
-  const totalIncome = teamSponsorDeals.reduce((sum, d) => sum + d.monthlyPayment * 12, 0);
+  // Monthly income — what actually gets credited each month
+  const totalMonthlyIncome = teamSponsorDeals.reduce((sum, d) => sum + d.monthlyPayment, 0);
+  // Annual figures for season projection
+  const totalAnnualIncome = totalMonthlyIncome * 12;
   const totalExpenses =
     teamDrivers.reduce((sum, d) => sum + d.salary, 0) +
     teamChiefs.reduce((sum, c) => sum + c.salary, 0) +
     teamPaidContracts.reduce((sum, c) => sum + c.annualCost, 0);
-  const netAnnual = totalIncome - totalExpenses;
+  const netAnnual = totalAnnualIncome - totalExpenses;
   const projectedBalance = playerTeam.budget + netAnnual;
 
   return (
@@ -256,7 +258,7 @@ export function Finance() {
       <IncomeSection
         deals={teamSponsorDeals}
         sponsors={gameState.sponsors}
-        totalIncome={totalIncome}
+        totalIncome={totalMonthlyIncome}
       />
 
       {/* Expenses Section */}

--- a/src/renderer/content/Sponsors.tsx
+++ b/src/renderer/content/Sponsors.tsx
@@ -517,7 +517,8 @@ export function Sponsors({ initialTab, onTabChange }: SponsorsProps) {
       (n): n is SponsorNegotiation =>
         n.stakeholderType === StakeholderType.Sponsor &&
         n.teamId === playerTeamId &&
-        (n.phase === NegotiationPhase.ResponseReceived ||
+        (n.phase === NegotiationPhase.AwaitingResponse ||
+          n.phase === NegotiationPhase.ResponseReceived ||
           n.phase === NegotiationPhase.PendingPlayerConfirmation)
     ).length;
   }, [gameState]);

--- a/src/renderer/content/Sponsors.tsx
+++ b/src/renderer/content/Sponsors.tsx
@@ -8,9 +8,12 @@ import { formatCurrency, formatCompact } from '../utils/format';
 import { seasonToYear } from '../../shared/utils/date-utils';
 import {
   SponsorTier,
+  NegotiationPhase,
+  StakeholderType,
   type Sponsor,
   type ActiveSponsorDeal,
   type GameState,
+  type SponsorNegotiation,
 } from '../../shared/domain';
 
 // ===========================================
@@ -503,7 +506,21 @@ interface SponsorsProps {
 export function Sponsors({ initialTab, onTabChange }: SponsorsProps) {
   const [activeTab, setActiveTab] = useState<SponsorsTab>(initialTab ?? 'summary');
   const [dealsTierFilter, setDealsTierFilter] = useState<SponsorTier | undefined>(undefined);
-  const [needsAttentionCount, setNeedsAttentionCount] = useState(0);
+
+  // Derive the "needs attention" count from gameState directly so the badge stays
+  // correct on every tab — including Summary, where <Deals> is unmounted.
+  const { gameState } = useDerivedGameState();
+  const needsAttentionCount = useMemo(() => {
+    if (!gameState) return 0;
+    const playerTeamId = gameState.player.teamId;
+    return gameState.negotiations.filter(
+      (n): n is SponsorNegotiation =>
+        n.stakeholderType === StakeholderType.Sponsor &&
+        n.teamId === playerTeamId &&
+        (n.phase === NegotiationPhase.ResponseReceived ||
+          n.phase === NegotiationPhase.PendingPlayerConfirmation)
+    ).length;
+  }, [gameState]);
 
   const handleTabChange = (tab: SponsorsTab) => {
     setActiveTab(tab);
@@ -532,11 +549,7 @@ export function Sponsors({ initialTab, onTabChange }: SponsorsProps) {
 
       {activeTab === 'summary' && <SponsorsSummary onEmptySlotClick={handleEmptySlotClick} />}
       {activeTab === 'deals' && (
-        <Deals
-          embedded
-          initialTierFilter={dealsTierFilter}
-          onNeedsAttentionCountChange={setNeedsAttentionCount}
-        />
+        <Deals embedded initialTierFilter={dealsTierFilter} />
       )}
     </div>
   );

--- a/src/renderer/content/Sponsors.tsx
+++ b/src/renderer/content/Sponsors.tsx
@@ -503,11 +503,11 @@ interface SponsorsProps {
 export function Sponsors({ initialTab, onTabChange }: SponsorsProps) {
   const [activeTab, setActiveTab] = useState<SponsorsTab>(initialTab ?? 'summary');
   const [dealsTierFilter, setDealsTierFilter] = useState<SponsorTier | undefined>(undefined);
+  const [needsAttentionCount, setNeedsAttentionCount] = useState(0);
 
   const handleTabChange = (tab: SponsorsTab) => {
     setActiveTab(tab);
     onTabChange?.(tab);
-    // Clear tier filter when manually switching tabs
     if (tab === 'summary') {
       setDealsTierFilter(undefined);
     }
@@ -527,10 +527,17 @@ export function Sponsors({ initialTab, onTabChange }: SponsorsProps) {
         tabs={TABS}
         activeTab={activeTab}
         onTabChange={handleTabChange}
+        badge={needsAttentionCount > 0 ? { tabId: 'deals', count: needsAttentionCount } : undefined}
       />
 
       {activeTab === 'summary' && <SponsorsSummary onEmptySlotClick={handleEmptySlotClick} />}
-      {activeTab === 'deals' && <Deals embedded initialTierFilter={dealsTierFilter} />}
+      {activeTab === 'deals' && (
+        <Deals
+          embedded
+          initialTierFilter={dealsTierFilter}
+          onNeedsAttentionCountChange={setNeedsAttentionCount}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/content/Sponsors.tsx
+++ b/src/renderer/content/Sponsors.tsx
@@ -507,10 +507,10 @@ export function Sponsors({ initialTab, onTabChange }: SponsorsProps) {
   const [activeTab, setActiveTab] = useState<SponsorsTab>(initialTab ?? 'summary');
   const [dealsTierFilter, setDealsTierFilter] = useState<SponsorTier | undefined>(undefined);
 
-  // Derive the "needs attention" count from gameState directly so the badge stays
+  // Derive the active-negotiation count from gameState directly so the badge stays
   // correct on every tab — including Summary, where <Deals> is unmounted.
   const { gameState } = useDerivedGameState();
-  const needsAttentionCount = useMemo(() => {
+  const activeNegotiationCount = useMemo(() => {
     if (!gameState) return 0;
     const playerTeamId = gameState.player.teamId;
     return gameState.negotiations.filter(
@@ -545,7 +545,7 @@ export function Sponsors({ initialTab, onTabChange }: SponsorsProps) {
         tabs={TABS}
         activeTab={activeTab}
         onTabChange={handleTabChange}
-        badge={needsAttentionCount > 0 ? { tabId: 'deals', count: needsAttentionCount } : undefined}
+        badge={activeNegotiationCount > 0 ? { tabId: 'deals', count: activeNegotiationCount } : undefined}
       />
 
       {activeTab === 'summary' && <SponsorsSummary onEmptySlotClick={handleEmptySlotClick} />}

--- a/src/shared/domain/engine-utils.ts
+++ b/src/shared/domain/engine-utils.ts
@@ -21,7 +21,7 @@ import type {
   SponsorContractTerms,
   GameDate,
 } from './types';
-import { ManufacturerType, NegotiationPhase, StakeholderType, DriverRole } from './types';
+import { ManufacturerType, NegotiationPhase, StakeholderType, DriverRole, SponsorTier } from './types';
 import { offsetDate } from '../utils/date-utils';
 
 /**
@@ -519,6 +519,15 @@ export const OFFER_EXPIRY_DAYS = 14;
  * Maximum number of negotiation rounds before stalemate
  */
 export const DEFAULT_MAX_ROUNDS = 5;
+
+/**
+ * Fixed slot counts per sponsor tier — shared between backend enforcement and frontend display.
+ */
+export const SPONSOR_SLOT_COUNTS: Record<SponsorTier, number> = {
+  title: 1,
+  major: 3,
+  minor: 5,
+};
 
 /**
  * Default neutral relationship score (0-100 scale)

--- a/src/shared/domain/types.ts
+++ b/src/shared/domain/types.ts
@@ -1450,6 +1450,8 @@ export enum NegotiationPhase {
   AwaitingResponse = 'awaiting-response',
   /** Counterparty has responded, player can act */
   ResponseReceived = 'response-received',
+  /** Sponsor accepted; waiting for player to Sign or Decline */
+  PendingPlayerConfirmation = 'pending-player-confirmation',
   /** Negotiation complete, deal signed */
   Completed = 'completed',
   /** Negotiation ended without deal (rejected or expired) */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -339,6 +339,8 @@ export const IpcChannels = {
   // Sponsor Negotiation
   SPONSOR_START_NEGOTIATION: 'sponsor:startNegotiation',
   SPONSOR_RESPOND_TO_OFFER: 'sponsor:respondToOffer',
+  SPONSOR_SIGN: 'sponsor:sign',
+  SPONSOR_DECLINE: 'sponsor:decline',
 
   // Mail
   MAIL_MARK_READ: 'mail:markRead',
@@ -566,6 +568,14 @@ export interface IpcInvokeMap {
   };
   [IpcChannels.SPONSOR_RESPOND_TO_OFFER]: {
     args: [params: RespondToSponsorOfferParams];
+    result: GameState;
+  };
+  [IpcChannels.SPONSOR_SIGN]: {
+    args: [negotiationId: string];
+    result: GameState;
+  };
+  [IpcChannels.SPONSOR_DECLINE]: {
+    args: [negotiationId: string];
     result: GameState;
   };
 


### PR DESCRIPTION
## Summary

- **Slot enforcement:** Backend rejects negotiations exceeding tier slot counts (`SPONSOR_SLOT_COUNTS`); Browse tab shows "Slot full." on Contact button when all slots for a tier are occupied
- **Sponsor-accept confirmation gate:** Sponsor accepting an offer now sets the negotiation to `PendingPlayerConfirmation` instead of auto-signing; player must click Sign or Decline; Sign is disabled with "Slot filled." if another deal filled the slot first
- **Signing consequences:** `signingBonus` is credited to `team.budget` on Sign; news headline broadcast; critical email delivered to player (simulation pauses); `SPONSOR_SIGNED` game event emitted
- **Monthly income tick:** `applyMonthlyIncomeTick` runs on the first day of each simulated month, crediting `monthlyPayment` for every active sponsor deal to the team's budget
- **Negotiations tab inbox restructure:** Three sections — Needs your attention (ResponseReceived + PendingPlayerConfirmation), Sent (AwaitingResponse), History (Failed + Completed, collapsed by default); badge counts only "Needs your attention"
- **No-redirect after Send Proposal:** Player stays on Browse tab; bottom-centre toast "Proposal sent to [Sponsor Name]." appears
- **Finance screen:** Income section now shows monthly amounts (not annual × 12); season projection still uses annual figures for correctness
- **CLI surface:** `scripts/sim-sponsors.ts` — three runnable scenarios (signing bonus, monthly income tick N months, slot block check); all pass; calls the same application code as the UI

## CLI usage (Tester)

```
npx ts-node --compiler-options '{"module":"commonjs"}' scripts/sim-sponsors.ts all
```

Or individual scenarios: `signing`, `monthly <N>`, `slots`

Refs #244 — Tier 1 only. Tiers 2 and 3 remain in scope under #244.