### PR TITLE
feat(sponsorship): Tier 2 — likelihood model, rep signals, rejection reasons

### DIFF
--- a/scripts/sim-sponsor-tier2.ts
+++ b/scripts/sim-sponsor-tier2.ts
@@ -45,7 +45,7 @@ import { GameStateManager } from '../src/main/services/game-state-manager';
 // Minimal builders
 // ---------------------------------------------------------------------------
 
-function makeTeam(id: string, position: number): Team {
+function makeTeam(id: string): Team {
   return {
     id,
     name: 'Test Team',
@@ -120,7 +120,7 @@ function makeNegotiation(
 }
 
 function makeMinimalState(teamId: string, sponsors: Sponsor[], deals: ActiveSponsorDeal[] = []): GameState {
-  const team = makeTeam(teamId, 5);
+  const team = makeTeam(teamId);
   return {
     teams: [team],
     sponsors,
@@ -176,7 +176,7 @@ function runBandScenario() {
     const result = evaluateSponsorOffer({
       negotiation: neg,
       sponsor,
-      team: makeTeam(teamId, 3),
+      team: makeTeam(teamId),
       allTeams: [],
       allSponsors: [sponsor],
       existingSponsorDeals: [],
@@ -227,7 +227,7 @@ function runSeedScenario() {
     const result = evaluateSponsorOffer({
       negotiation: neg,
       sponsor,
-      team: makeTeam(teamId, 3),
+      team: makeTeam(teamId),
       allTeams: [],
       allSponsors: [sponsor],
       existingSponsorDeals: [],
@@ -282,7 +282,7 @@ function runReasonsScenario() {
     const result = evaluateSponsorOffer({
       negotiation: neg,
       sponsor: targetSponsor,
-      team: makeTeam(teamId, 3),
+      team: makeTeam(teamId),
       allTeams: [],
       allSponsors: [rivalSponsor, targetSponsor],
       existingSponsorDeals: [existingDeal],
@@ -305,7 +305,7 @@ function runReasonsScenario() {
     const result = evaluateSponsorOffer({
       negotiation: neg,
       sponsor,
-      team: makeTeam(teamId, 3),
+      team: makeTeam(teamId),
       allTeams: [],
       allSponsors: [sponsor],
       existingSponsorDeals: [],
@@ -335,7 +335,7 @@ function runReasonsScenario() {
       const result = evaluateSponsorOffer({
         negotiation: neg,
         sponsor,
-        team: makeTeam(teamId, 3),
+        team: makeTeam(teamId),
         allTeams: [],
         allSponsors: [sponsor],
         existingSponsorDeals: [],
@@ -371,7 +371,7 @@ function runReasonsScenario() {
       const result = evaluateSponsorOffer({
         negotiation: neg,
         sponsor,
-        team: makeTeam(teamId, 3),
+        team: makeTeam(teamId),
         allTeams: [],
         allSponsors: [sponsor],
         existingSponsorDeals: [],
@@ -426,9 +426,11 @@ function runReasonsScenario() {
     };
 
     const state = makeMinimalState(teamId, [sponsor1, sponsor2]);
-    // Minor tier has 2 slots (from SPONSOR_SLOT_COUNTS). To trigger the auto-fail
-    // we need all slots to be taken. Minor has 2 slots, so we fill slot 1 already.
-    (state.sponsorDeals as ActiveSponsorDeal[]).push(makeSponsorDeal('sponsor-existing', teamId, SponsorTier.Minor));
+    // Minor tier has 5 slots (from SPONSOR_SLOT_COUNTS). Pre-fill 4 so that signing
+    // neg-a fills the last slot and triggers the auto-fail of neg-b.
+    for (let i = 0; i < 4; i++) {
+      (state.sponsorDeals as ActiveSponsorDeal[]).push(makeSponsorDeal(`sponsor-existing-${i}`, teamId, SponsorTier.Minor));
+    }
     state.negotiations = [negA, negB] as GameState['negotiations'];
     GameStateManager.currentState = state;
 

--- a/scripts/sim-sponsor-tier2.ts
+++ b/scripts/sim-sponsor-tier2.ts
@@ -1,0 +1,456 @@
+/**
+ * Sponsor Tier 2 simulation CLI — used by Tricia (Tester) to verify
+ * Tier 2 sponsorship mechanics: probability model, seeded rolls, rejection reasons.
+ *
+ * Usage:
+ *   npx ts-node --compiler-options '{"module":"commonjs"}' scripts/sim-sponsor-tier2.ts [scenario]
+ *
+ * Scenarios:
+ *   band           Print probability + band for a range of monthly payment values
+ *   seed           Show that different negotiation seeds can produce different outcomes
+ *   reasons        Trigger all five rejection-reason cases and print their text
+ *
+ * All scenarios run by default when no argument is supplied.
+ */
+
+import { randomUUID } from 'crypto';
+import type {
+  GameState,
+  SponsorNegotiation,
+  SponsorContractTerms,
+  Sponsor,
+  Team,
+  ActiveSponsorDeal,
+} from '../src/shared/domain/types';
+import {
+  SponsorTier,
+  SponsorPlacement,
+  NegotiationPhase,
+  StakeholderType,
+  ResponseType,
+} from '../src/shared/domain/types';
+import {
+  computeAcceptanceProbabilities,
+  getLikelihoodBand,
+  hashString,
+  seededRandom,
+} from '../src/shared/domain/sponsor-probability';
+import {
+  evaluateSponsorOffer,
+  calculateSponsorValuation,
+} from '../src/main/engines/evaluators/sponsor-evaluator';
+import { GameStateManager } from '../src/main/services/game-state-manager';
+
+// ---------------------------------------------------------------------------
+// Minimal builders
+// ---------------------------------------------------------------------------
+
+function makeTeam(id: string, position: number): Team {
+  return {
+    id,
+    name: 'Test Team',
+    shortName: 'TEST',
+    color: '#ff0000',
+    budget: 5_000_000,
+    reputation: 70,
+    initialSponsorIds: [],
+  } as unknown as Team;
+}
+
+function makeSponsor(overrides: Partial<Sponsor> = {}): Sponsor {
+  return {
+    id: 'sponsor-test',
+    name: 'Test Sponsor',
+    industry: 'technology',
+    tier: SponsorTier.Major,
+    baseMonthlyPayment: 1_000_000,
+    minReputation: 40,
+    rivalGroup: null,
+    logoUrl: null,
+    ...overrides,
+  };
+}
+
+function makeSponsorDeal(sponsorId: string, teamId: string, tier: SponsorTier): ActiveSponsorDeal {
+  return {
+    sponsorId,
+    teamId,
+    tier,
+    signingBonus: 0,
+    monthlyPayment: 500_000,
+    guaranteed: false,
+    startSeason: 1,
+    endSeason: 3,
+  };
+}
+
+function makeNegotiation(
+  id: string,
+  teamId: string,
+  sponsorId: string,
+  terms: SponsorContractTerms,
+  roundNumber = 1,
+  isUltimatum = false
+): SponsorNegotiation {
+  return {
+    id,
+    stakeholderType: StakeholderType.Sponsor,
+    teamId,
+    sponsorId,
+    phase: NegotiationPhase.AwaitingResponse,
+    forSeason: 2,
+    startedDate: { year: 2025, month: 1, day: 1 },
+    lastActivityDate: { year: 2025, month: 1, day: 15 },
+    rounds: [
+      {
+        roundNumber,
+        offeredBy: 'player' as const,
+        terms,
+        offeredDate: { year: 2025, month: 1, day: 1 },
+        expiresDate: { year: 2025, month: 2, day: 1 },
+        isUltimatum,
+      },
+    ],
+    currentRound: roundNumber,
+    maxRounds: 4,
+    relationshipScoreBefore: 50,
+    hasCompetingOffer: false,
+    isProactiveOutreach: false,
+  };
+}
+
+function makeMinimalState(teamId: string, sponsors: Sponsor[], deals: ActiveSponsorDeal[] = []): GameState {
+  const team = makeTeam(teamId, 5);
+  return {
+    teams: [team],
+    sponsors,
+    sponsorDeals: deals,
+    negotiations: [],
+    calendarEvents: [],
+    events: [],
+    currentDate: { year: 2025, month: 1, day: 15 },
+    currentSeason: {
+      seasonNumber: 1,
+      constructorStandings: [{ teamId, points: 100, position: 3, wins: 2, podiums: 4, polePositions: 1 }],
+    } as GameState['currentSeason'],
+    player: { teamId } as GameState['player'],
+  } as unknown as GameState;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Band verification
+// ---------------------------------------------------------------------------
+
+function runBandScenario() {
+  console.log('\n===== SCENARIO 1: Band Verification =====');
+  console.log('Verifies that the band shown in the UI is driven by the actual engine probability.\n');
+
+  const teamId = 'team-1';
+  const sponsor = makeSponsor({ minReputation: 40 });
+  const teamPosition = 3;
+  const totalTeams = 10;
+
+  // Compute valuation the same way the engine does
+  const valuation = calculateSponsorValuation(sponsor, teamPosition, totalTeams);
+  console.log(`willingPayment = $${valuation.willingPayment.toLocaleString()}/mo`);
+  console.log(`isBelowHardGate = ${valuation.isBelowHardGate}`);
+  console.log(`isBelowSoftGate = ${valuation.isBelowSoftGate}`);
+  console.log('');
+
+  const testRatios = [0.50, 0.60, 0.70, 0.80, 0.90, 0.95, 1.00, 1.10, 1.20];
+  console.log('paymentRatio | p_accept | p_counter | p_reject | band');
+  console.log('-------------|----------|-----------|----------|---------');
+
+  for (const ratio of testRatios) {
+    const offered = Math.round(valuation.willingPayment * ratio);
+    const probs = computeAcceptanceProbabilities(ratio, valuation.isBelowHardGate, valuation.isBelowSoftGate);
+    const band = getLikelihoodBand(probs);
+
+    // Also run through the engine to verify the band matches the seeded decision
+    const neg = makeNegotiation(randomUUID(), teamId, sponsor.id, {
+      monthlyPayment: offered,
+      signingBonus: 0,
+      duration: 2,
+      placement: SponsorPlacement.Secondary,
+    });
+    const result = evaluateSponsorOffer({
+      negotiation: neg,
+      sponsor,
+      team: makeTeam(teamId, 3),
+      allTeams: [],
+      allSponsors: [sponsor],
+      existingSponsorDeals: [],
+      relationshipScore: 50,
+      teamPosition,
+      totalTeams,
+    });
+
+    const match = result.acceptanceProbability !== undefined
+      ? Math.abs(result.acceptanceProbability - probs.accept) < 0.001 ? '✓' : '✗ MISMATCH'
+      : '?';
+
+    console.log(
+      `${ratio.toFixed(2)}         | ${probs.accept.toFixed(3)}  | ${probs.counter.toFixed(3)}    | ${probs.reject.toFixed(3)}   | ${band} [engine:${result.responseType} prob:${match}]`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Seed variation
+// ---------------------------------------------------------------------------
+
+function runSeedScenario() {
+  console.log('\n===== SCENARIO 2: Seeded Roll Variation =====');
+  console.log('Verifies that different per-negotiation seeds can produce different outcomes.\n');
+
+  const teamId = 'team-1';
+  const sponsor = makeSponsor({ minReputation: 40 });
+  const teamPosition = 3;
+  const totalTeams = 10;
+
+  // Use a toss-up payment ratio (near INSTANT_ACCEPT_RATIO) where accept & counter have similar probability
+  const valuation = calculateSponsorValuation(sponsor, teamPosition, totalTeams);
+  const tossUpOffered = Math.round(valuation.willingPayment * 0.95);
+  console.log(`Offer: $${tossUpOffered.toLocaleString()}/mo (ratio ~0.95, toss-up range)`);
+  console.log('Running 20 evaluations with different negotiation IDs:\n');
+
+  const outcomes: Record<string, number> = { Accept: 0, Counter: 0, Reject: 0 };
+
+  for (let i = 0; i < 20; i++) {
+    const negId = `neg-seed-test-${i}`;
+    const neg = makeNegotiation(negId, teamId, sponsor.id, {
+      monthlyPayment: tossUpOffered,
+      signingBonus: 0,
+      duration: 2,
+      placement: SponsorPlacement.Secondary,
+    });
+    const result = evaluateSponsorOffer({
+      negotiation: neg,
+      sponsor,
+      team: makeTeam(teamId, 3),
+      allTeams: [],
+      allSponsors: [sponsor],
+      existingSponsorDeals: [],
+      relationshipScore: 50,
+      teamPosition,
+      totalTeams,
+    });
+    const label = result.responseType === ResponseType.Accept ? 'Accept'
+      : result.responseType === ResponseType.Counter ? 'Counter'
+      : 'Reject';
+    outcomes[label]++;
+
+    // Print raw seed → roll
+    const seed = hashString(`${negId}:1`);
+    const roll = seededRandom(seed);
+    process.stdout.write(`  ID ${String(i).padStart(2)}: seed=${seed.toString().padStart(10)} roll=${roll.toFixed(4)} → ${label}\n`);
+  }
+
+  console.log(`\nDistribution: Accept=${outcomes.Accept}  Counter=${outcomes.Counter}  Reject=${outcomes.Reject}`);
+  const distinctOutcomes = Object.values(outcomes).filter((v) => v > 0).length;
+  if (distinctOutcomes >= 2) {
+    console.log('✓ Multiple outcomes observed — seeded roll is live.');
+  } else {
+    console.log('! Only one outcome observed. Payment ratio may be too far from a boundary — try a different ratio.');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3: All five rejection reasons
+// ---------------------------------------------------------------------------
+
+function runReasonsScenario() {
+  console.log('\n===== SCENARIO 3: Rejection Reasons =====');
+  console.log('Verifies all five rejection-reason strings are populated correctly.\n');
+
+  const teamId = 'team-1';
+  const terms = (monthly: number): SponsorContractTerms => ({
+    monthlyPayment: monthly,
+    signingBonus: 0,
+    duration: 2,
+    placement: SponsorPlacement.Secondary,
+  });
+
+  // ── Case 1: Rival conflict ──────────────────────────────���──────────────────
+  {
+    console.log('Case 1 — Rival conflict');
+    const rivalSponsor = makeSponsor({ id: 'rival-sponsor', name: 'Rival Co', rivalGroup: 'auto-group' });
+    const targetSponsor = makeSponsor({ id: 'target-sponsor', name: 'Target Sponsor', rivalGroup: 'auto-group' });
+    const existingDeal = makeSponsorDeal('rival-sponsor', teamId, SponsorTier.Major);
+
+    const neg = makeNegotiation(randomUUID(), teamId, 'target-sponsor', terms(1_000_000));
+    const result = evaluateSponsorOffer({
+      negotiation: neg,
+      sponsor: targetSponsor,
+      team: makeTeam(teamId, 3),
+      allTeams: [],
+      allSponsors: [rivalSponsor, targetSponsor],
+      existingSponsorDeals: [existingDeal],
+      relationshipScore: 50,
+      teamPosition: 3,
+      totalTeams: 10,
+    });
+    const pass = result.responseType === ResponseType.Reject && !!result.rejectionReason;
+    console.log(`  responseType: ${result.responseType}`);
+    console.log(`  rejectionReason: "${result.rejectionReason}"`);
+    console.log(`  ${pass ? '✓ PASS' : '✗ FAIL'}\n`);
+  }
+
+  // ── Case 2: Below reputation floor ────────────────────────────────────────
+  {
+    console.log('Case 2 — Below reputation floor');
+    // High minReputation so a mid-table team fails the hard gate
+    const sponsor = makeSponsor({ minReputation: 90 });
+    const neg = makeNegotiation(randomUUID(), teamId, sponsor.id, terms(1_000_000));
+    const result = evaluateSponsorOffer({
+      negotiation: neg,
+      sponsor,
+      team: makeTeam(teamId, 3),
+      allTeams: [],
+      allSponsors: [sponsor],
+      existingSponsorDeals: [],
+      relationshipScore: 50,
+      teamPosition: 9, // Near last → low reputation
+      totalTeams: 10,
+    });
+    const pass = result.responseType === ResponseType.Reject && !!result.rejectionReason;
+    console.log(`  responseType: ${result.responseType}`);
+    console.log(`  rejectionReason: "${result.rejectionReason}"`);
+    console.log(`  ${pass ? '✓ PASS' : '✗ FAIL'}\n`);
+  }
+
+  // ── Case 3: Offer too low ──────────────────────────────────────────────────
+  {
+    console.log('Case 3 — Offer too low');
+    const sponsor = makeSponsor({ minReputation: 40 });
+    // Offer at 30% of willing payment — well below REJECT_RATIO (0.6)
+    const valuation = calculateSponsorValuation(sponsor, 3, 10);
+    const lowOffer = Math.round(valuation.willingPayment * 0.30);
+
+    // Use a negotiation ID that produces a roll in the Reject range
+    // We'll try multiple IDs to find one that actually rejects (vs counter)
+    let found = false;
+    for (let i = 0; i < 50; i++) {
+      const neg = makeNegotiation(`neg-low-offer-${i}`, teamId, sponsor.id, terms(lowOffer));
+      const result = evaluateSponsorOffer({
+        negotiation: neg,
+        sponsor,
+        team: makeTeam(teamId, 3),
+        allTeams: [],
+        allSponsors: [sponsor],
+        existingSponsorDeals: [],
+        relationshipScore: 50,
+        teamPosition: 3,
+        totalTeams: 10,
+      });
+      if (result.responseType === ResponseType.Reject && result.rejectionReason?.includes('looking closer')) {
+        console.log(`  responseType: ${result.responseType}`);
+        console.log(`  rejectionReason: "${result.rejectionReason}"`);
+        console.log(`  ✓ PASS\n`);
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      // At 0.30 ratio, p_reject is very high — this should always reject
+      console.log('  ! Could not find an "offer too low" rejection in 50 tries — check threshold\n');
+    }
+  }
+
+  // ── Case 4: Max rounds ────────────────────────────────────────────────────
+  {
+    console.log('Case 4 — Max rounds (≥4 rounds)');
+    const sponsor = makeSponsor({ minReputation: 40 });
+    const valuation = calculateSponsorValuation(sponsor, 3, 10);
+    // Mid-range offer that might counter, but we force round 4 which triggers the max-rounds rejection reason
+    const midOffer = Math.round(valuation.willingPayment * 0.70);
+
+    let found = false;
+    for (let i = 0; i < 50; i++) {
+      const neg = makeNegotiation(`neg-maxround-${i}`, teamId, sponsor.id, terms(midOffer), 4);
+      const result = evaluateSponsorOffer({
+        negotiation: neg,
+        sponsor,
+        team: makeTeam(teamId, 3),
+        allTeams: [],
+        allSponsors: [sponsor],
+        existingSponsorDeals: [],
+        relationshipScore: 50,
+        teamPosition: 3,
+        totalTeams: 10,
+      });
+      if (result.rejectionReason?.includes("tried to find common ground")) {
+        console.log(`  responseType: ${result.responseType}`);
+        console.log(`  rejectionReason: "${result.rejectionReason}"`);
+        console.log(`  ✓ PASS\n`);
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      console.log('  ! Max-rounds rejection reason not triggered in 50 tries.\n');
+    }
+  }
+
+  // ── Case 5: Slot filled by other deal ─────────────────────────────────────
+  {
+    console.log('Case 5 — Slot filled by other deal');
+    const sponsor1 = makeSponsor({ id: 'sponsor-a', name: 'Sponsor A', tier: SponsorTier.Minor });
+    const sponsor2 = makeSponsor({ id: 'sponsor-b', name: 'Sponsor B', tier: SponsorTier.Minor });
+    const sponsorTerms: SponsorContractTerms = {
+      monthlyPayment: 200_000,
+      signingBonus: 100_000,
+      duration: 2,
+      placement: SponsorPlacement.Tertiary,
+    };
+    const negA: SponsorNegotiation = {
+      id: 'neg-a',
+      stakeholderType: StakeholderType.Sponsor,
+      teamId,
+      sponsorId: 'sponsor-a',
+      phase: NegotiationPhase.PendingPlayerConfirmation,
+      forSeason: 2,
+      startedDate: { year: 2025, month: 1, day: 1 },
+      lastActivityDate: { year: 2025, month: 1, day: 15 },
+      rounds: [{ roundNumber: 1, offeredBy: 'counterparty' as const, terms: sponsorTerms, offeredDate: { year: 2025, month: 1, day: 1 }, expiresDate: { year: 2025, month: 2, day: 1 } }],
+      currentRound: 1,
+      maxRounds: 4,
+      relationshipScoreBefore: 50,
+      hasCompetingOffer: false,
+      isProactiveOutreach: false,
+    };
+    const negB: SponsorNegotiation = {
+      ...negA,
+      id: 'neg-b',
+      sponsorId: 'sponsor-b',
+    };
+
+    const state = makeMinimalState(teamId, [sponsor1, sponsor2]);
+    // Minor tier has 2 slots (from SPONSOR_SLOT_COUNTS). To trigger the auto-fail
+    // we need all slots to be taken. Minor has 2 slots, so we fill slot 1 already.
+    (state.sponsorDeals as ActiveSponsorDeal[]).push(makeSponsorDeal('sponsor-existing', teamId, SponsorTier.Minor));
+    state.negotiations = [negA, negB] as GameState['negotiations'];
+    GameStateManager.currentState = state;
+
+    // Sign neg-a — this fills the last slot, which should auto-fail neg-b
+    GameStateManager.signSponsorDeal('neg-a');
+
+    const updatedNegB = state.negotiations.find((n) => n.id === 'neg-b') as SponsorNegotiation;
+    const pass =
+      updatedNegB?.phase === NegotiationPhase.Failed &&
+      !!updatedNegB.rejectionReason;
+    console.log(`  neg-b phase after signing neg-a: ${updatedNegB?.phase}`);
+    console.log(`  rejectionReason: "${updatedNegB?.rejectionReason ?? '(none)'}"`);
+    console.log(`  ${pass ? '✓ PASS' : '✗ FAIL'}\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+const scenario = process.argv[2] ?? 'all';
+
+if (scenario === 'band' || scenario === 'all') runBandScenario();
+if (scenario === 'seed' || scenario === 'all') runSeedScenario();
+if (scenario === 'reasons' || scenario === 'all') runReasonsScenario();

--- a/src/main/engines/evaluators/index.ts
+++ b/src/main/engines/evaluators/index.ts
@@ -48,10 +48,12 @@ export {
   evaluateSponsorOffer,
   hasRivalGroupConflict,
   calculateSponsorValuation,
-  getPlacementForTier,
   getSponsorTierDisplayName,
   type SponsorEvaluationInput,
 } from './sponsor-evaluator';
+
+// Re-export shared sponsor placement helper for callers that import via the evaluators barrel
+export { getPlacementForTier } from '../../../shared/domain/sponsor-probability';
 
 export {
   evaluateStaffOffer,

--- a/src/main/engines/evaluators/sponsor-evaluator.ts
+++ b/src/main/engines/evaluators/sponsor-evaluator.ts
@@ -21,15 +21,16 @@ import type {
   ActiveSponsorDeal,
 } from '../../../shared/domain/types';
 import type { NegotiationEvaluationResult } from '../../../shared/domain/engines';
-import { ResponseType, ResponseTone, SponsorTier, SponsorPlacement } from '../../../shared/domain';
+import { ResponseType, ResponseTone, SponsorTier } from '../../../shared/domain';
 import {
-  INSTANT_ACCEPT_RATIO,
   REJECT_RATIO,
   SOFT_GATE_MULTIPLIER,
   HARD_GATE_MULTIPLIER,
   hashString,
   seededRandom,
   computeAcceptanceProbabilities,
+  computeReputationRatio,
+  calculateWillingPayment,
 } from '../../../shared/domain/sponsor-probability';
 
 // =============================================================================
@@ -48,20 +49,6 @@ const MAX_EXIT_CLAUSE_POSITION = 10;
 
 /** Base exit clause position for teams at soft gate threshold */
 const BASE_EXIT_CLAUSE_POSITION = 5;
-
-// -----------------------------------------------------------------------------
-// Valuation Thresholds
-// -----------------------------------------------------------------------------
-
-/**
- * Premium multiplier for teams exceeding minReputation significantly
- * Top teams can negotiate higher than base payment
- */
-const PREMIUM_REPUTATION_THRESHOLD = 1.2; // 20% above minReputation
-const MAX_PREMIUM_MULTIPLIER = 1.25; // Up to 25% premium
-
-/** Discount multiplier for teams near minReputation */
-const DISCOUNT_MULTIPLIER_FLOOR = 0.7; // At most 30% discount from base
 
 // -----------------------------------------------------------------------------
 // Counter-Offer Strategy
@@ -179,30 +166,11 @@ export function calculateSponsorValuation(
   teamPosition: number,
   totalTeams: number
 ): SponsorValuation {
-  // Calculate team's effective reputation from standings position
-  // Position 1 = 100%, Position last = ~10%
-  const positionScore = 1 - (teamPosition - 1) / (totalTeams - 1 || 1);
-  const effectiveReputation = positionScore * 100;
-
-  // Compare to sponsor's minimum reputation requirement
-  const reputationRatio = effectiveReputation / sponsor.minReputation;
-
-  // Determine gate status
+  const reputationRatio = computeReputationRatio(teamPosition, totalTeams, sponsor.minReputation);
   const isBelowHardGate = reputationRatio < HARD_GATE_MULTIPLIER;
   const isBelowSoftGate = reputationRatio < SOFT_GATE_MULTIPLIER;
 
-  // Calculate willing payment (monthly)
-  let willingPayment = sponsor.baseMonthlyPayment;
-
-  if (reputationRatio >= PREMIUM_REPUTATION_THRESHOLD) {
-    // Premium team - sponsor pays more for exposure
-    const premiumFactor = Math.min(reputationRatio - 1, MAX_PREMIUM_MULTIPLIER - 1);
-    willingPayment = sponsor.baseMonthlyPayment * (1 + premiumFactor);
-  } else if (reputationRatio < 1.0) {
-    // Below threshold - sponsor pays less
-    const discountFactor = Math.max(reputationRatio, DISCOUNT_MULTIPLIER_FLOOR);
-    willingPayment = sponsor.baseMonthlyPayment * discountFactor;
-  }
+  const willingPayment = calculateWillingPayment(sponsor, teamPosition, totalTeams);
 
   // Calculate protection level (0-1)
   // Higher = more protective terms (exit clause, shorter duration, lower signing bonus)
@@ -216,7 +184,7 @@ export function calculateSponsorValuation(
   }
 
   return {
-    willingPayment: Math.round(willingPayment),
+    willingPayment,
     protectionLevel,
     isBelowSoftGate,
     isBelowHardGate,
@@ -500,21 +468,6 @@ export function evaluateSponsorOffer(input: SponsorEvaluationInput): Negotiation
 // =============================================================================
 // SPONSOR PLACEMENT HELPERS
 // =============================================================================
-
-/**
- * Get the appropriate placement level based on sponsor tier.
- */
-export function getPlacementForTier(tier: SponsorTier): SponsorPlacement {
-  switch (tier) {
-    case SponsorTier.Title:
-      return SponsorPlacement.Primary;
-    case SponsorTier.Major:
-      return SponsorPlacement.Secondary;
-    case SponsorTier.Minor:
-    default:
-      return SponsorPlacement.Tertiary;
-  }
-}
 
 /**
  * Get display name for sponsor tier (lowercase for news headlines).

--- a/src/main/engines/evaluators/sponsor-evaluator.ts
+++ b/src/main/engines/evaluators/sponsor-evaluator.ts
@@ -22,6 +22,15 @@ import type {
 } from '../../../shared/domain/types';
 import type { NegotiationEvaluationResult } from '../../../shared/domain/engines';
 import { ResponseType, ResponseTone, SponsorTier, SponsorPlacement } from '../../../shared/domain';
+import {
+  INSTANT_ACCEPT_RATIO,
+  REJECT_RATIO,
+  SOFT_GATE_MULTIPLIER,
+  HARD_GATE_MULTIPLIER,
+  hashString,
+  seededRandom,
+  computeAcceptanceProbabilities,
+} from '../../../shared/domain/sponsor-probability';
 
 // =============================================================================
 // CONSTANTS
@@ -33,22 +42,6 @@ const BASE_RESPONSE_DELAY_DAYS = 3;
 /** Min/max response delay */
 const MIN_RESPONSE_DELAY_DAYS = 1;
 const MAX_RESPONSE_DELAY_DAYS = 5;
-
-// -----------------------------------------------------------------------------
-// Reputation Gates
-// -----------------------------------------------------------------------------
-
-/**
- * Soft gate threshold multiplier
- * Teams below minReputation * SOFT_GATE_MULTIPLIER get demanding counter-offers
- */
-const SOFT_GATE_MULTIPLIER = 0.9; // 10% below minReputation = soft gate
-
-/**
- * Hard gate threshold multiplier
- * Teams below minReputation * HARD_GATE_MULTIPLIER get rejected
- */
-const HARD_GATE_MULTIPLIER = 0.7; // 30% below minReputation = hard rejection
 
 /** Maximum exit clause position (sponsor can demand team finish above this) */
 const MAX_EXIT_CLAUSE_POSITION = 10;
@@ -84,16 +77,6 @@ const MINOR_SIGNING_BONUS_MONTHS = 1; // 1 month
 
 /** Maximum contract duration sponsors will accept */
 const MAX_CONTRACT_DURATION = 3;
-
-// -----------------------------------------------------------------------------
-// Acceptance Thresholds
-// -----------------------------------------------------------------------------
-
-/** Ratio of offered payment to sponsor's willing payment for instant accept */
-const INSTANT_ACCEPT_RATIO = 0.95; // Accept if offer >= 95% of willing amount
-
-/** Ratio below which sponsor rejects outright (too cheap for them) */
-const REJECT_RATIO = 0.6; // Reject if offer < 60% of willing amount
 
 /** Maximum rounds before sponsor walks away */
 const MAX_NEGOTIATION_ROUNDS = 4;
@@ -160,6 +143,25 @@ export function hasRivalGroupConflict(
     }
   }
   return false;
+}
+
+/**
+ * Return the name of the existing sponsor causing a rivalGroup conflict, or null.
+ */
+export function getRivalConflictSponsorName(
+  sponsorRivalGroup: string | null,
+  existingSponsorDeals: ActiveSponsorDeal[],
+  allSponsors: Sponsor[]
+): string | null {
+  if (!sponsorRivalGroup) return null;
+
+  for (const deal of existingSponsorDeals) {
+    const existingSponsor = allSponsors.find((s) => s.id === deal.sponsorId);
+    if (existingSponsor?.rivalGroup === sponsorRivalGroup) {
+      return existingSponsor.name;
+    }
+  }
+  return null;
 }
 
 // =============================================================================
@@ -307,11 +309,29 @@ function calculateResponseDelay(relationshipScore: number): number {
 }
 
 // =============================================================================
+// REJECTION REASON HELPERS
+// =============================================================================
+
+function formatPaymentHint(amount: number): string {
+  if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
+  if (amount >= 1_000) return `$${Math.round(amount / 1_000)}k`;
+  return `$${Math.round(amount)}`;
+}
+
+function buildOfferTooLowReason(willingPayment: number): string {
+  const low = Math.round(willingPayment * 0.95);
+  const high = Math.round(willingPayment * 1.10);
+  return `We can't accept this rate — we're looking closer to ${formatPaymentHint(low)}–${formatPaymentHint(high)}/mo.`;
+}
+
+// =============================================================================
 // MAIN EVALUATOR
 // =============================================================================
 
 /**
  * Evaluate a sponsor contract offer from the sponsor's perspective.
+ * Uses a probability model with a per-negotiation seeded roll so that
+ * save-load preserves outcomes for identical inputs.
  */
 export function evaluateSponsorOffer(input: SponsorEvaluationInput): NegotiationEvaluationResult {
   const {
@@ -336,6 +356,7 @@ export function evaluateSponsorOffer(input: SponsorEvaluationInput): Negotiation
       responseDelayDays: BASE_RESPONSE_DELAY_DAYS,
       isNewsworthy: false,
       relationshipChange: REJECT_RELATIONSHIP_PENALTY,
+      rejectionReason: 'We could not process your offer.',
     };
   }
 
@@ -345,14 +366,17 @@ export function evaluateSponsorOffer(input: SponsorEvaluationInput): Negotiation
   // ==========================================================================
   // HARD REJECTION: rivalGroup conflict
   // ==========================================================================
-  if (hasRivalGroupConflict(sponsor.rivalGroup, existingSponsorDeals, allSponsors)) {
+  const rivalName = getRivalConflictSponsorName(sponsor.rivalGroup, existingSponsorDeals, allSponsors);
+  if (rivalName !== null) {
     return {
       responseType: ResponseType.Reject,
       counterTerms: null,
       responseTone: ResponseTone.Professional,
       responseDelayDays: MIN_RESPONSE_DELAY_DAYS,
       isNewsworthy: false,
-      relationshipChange: 0, // No relationship penalty for conflict
+      relationshipChange: 0,
+      rejectionReason: `We can't partner while you hold ${rivalName}.`,
+      acceptanceProbability: 0,
     };
   }
 
@@ -370,17 +394,19 @@ export function evaluateSponsorOffer(input: SponsorEvaluationInput): Negotiation
       responseDelayDays: MIN_RESPONSE_DELAY_DAYS,
       isNewsworthy: false,
       relationshipChange: REJECT_RELATIONSHIP_PENALTY,
+      rejectionReason: "Your team's profile is below what our brand requires.",
+      acceptanceProbability: 0,
     };
   }
 
   // ==========================================================================
-  // Evaluate the offered payment
+  // Evaluate the offered payment using the probability model
   // ==========================================================================
   const offeredPayment = terms.monthlyPayment;
   const paymentRatio = offeredPayment / valuation.willingPayment;
 
   // ==========================================================================
-  // Handle ultimatums
+  // Handle ultimatums (bypass probability — ultimatums are categorical)
   // ==========================================================================
   if (currentRound.isUltimatum) {
     // Player issued ultimatum - accept or reject only
@@ -392,6 +418,7 @@ export function evaluateSponsorOffer(input: SponsorEvaluationInput): Negotiation
         responseDelayDays: MIN_RESPONSE_DELAY_DAYS,
         isNewsworthy: sponsor.tier === SponsorTier.Title,
         relationshipChange: ACCEPT_RELATIONSHIP_BOOST,
+        acceptanceProbability: 1,
       };
     } else {
       return {
@@ -401,16 +428,31 @@ export function evaluateSponsorOffer(input: SponsorEvaluationInput): Negotiation
         responseDelayDays: MIN_RESPONSE_DELAY_DAYS,
         isNewsworthy: false,
         relationshipChange: REJECT_RELATIONSHIP_PENALTY,
+        rejectionReason: buildOfferTooLowReason(valuation.willingPayment),
+        acceptanceProbability: 0,
       };
     }
   }
 
   // ==========================================================================
-  // Decision logic
+  // Probability-based decision
   // ==========================================================================
+  const probs = computeAcceptanceProbabilities(
+    paymentRatio,
+    valuation.isBelowHardGate,
+    valuation.isBelowSoftGate
+  );
 
-  // Accept if offer is good enough and team is above soft gate
-  if (paymentRatio >= INSTANT_ACCEPT_RATIO && !valuation.isBelowSoftGate) {
+  // Seeded roll: derive seed from negotiation ID + round so outcomes are
+  // deterministic for identical (negotiation, round, terms) combos.
+  const seed = hashString(`${negotiation.id}:${roundNumber}`);
+  const roll = seededRandom(seed);
+
+  // Check if we should issue ultimatum on the counter path
+  const shouldUltimatum = roundNumber >= MAX_NEGOTIATION_ROUNDS;
+
+  if (roll < probs.accept) {
+    // Accept
     return {
       responseType: ResponseType.Accept,
       counterTerms: null,
@@ -418,38 +460,40 @@ export function evaluateSponsorOffer(input: SponsorEvaluationInput): Negotiation
       responseDelayDays: calculateResponseDelay(relationshipScore),
       isNewsworthy: sponsor.tier === SponsorTier.Title,
       relationshipChange: ACCEPT_RELATIONSHIP_BOOST,
+      acceptanceProbability: probs.accept,
     };
   }
 
-  // Reject if offer is too low
-  if (paymentRatio < REJECT_RATIO) {
+  if (roll < probs.accept + probs.counter) {
+    // Counter
+    const counterTerms = generateCounterTerms(terms, sponsor, valuation);
     return {
-      responseType: ResponseType.Reject,
-      counterTerms: null,
-      responseTone: ResponseTone.Disappointed,
+      responseType: ResponseType.Counter,
+      counterTerms,
+      responseTone: valuation.isBelowSoftGate ? ResponseTone.Professional : ResponseTone.Enthusiastic,
       responseDelayDays: calculateResponseDelay(relationshipScore),
       isNewsworthy: false,
-      relationshipChange: REJECT_RELATIONSHIP_PENALTY,
+      relationshipChange: 0,
+      isUltimatum: shouldUltimatum,
+      acceptanceProbability: probs.accept,
     };
   }
 
-  // ==========================================================================
-  // Counter-offer
-  // ==========================================================================
-
-  // Check if we should issue ultimatum
-  const shouldUltimatum = roundNumber >= MAX_NEGOTIATION_ROUNDS;
-
-  const counterTerms = generateCounterTerms(terms, sponsor, valuation);
+  // Reject
+  const isMaxRounds = roundNumber >= MAX_NEGOTIATION_ROUNDS;
+  const rejectionReason = isMaxRounds
+    ? "We've tried to find common ground but can't agree."
+    : buildOfferTooLowReason(valuation.willingPayment);
 
   return {
-    responseType: ResponseType.Counter,
-    counterTerms,
-    responseTone: valuation.isBelowSoftGate ? ResponseTone.Professional : ResponseTone.Enthusiastic,
+    responseType: ResponseType.Reject,
+    counterTerms: null,
+    responseTone: ResponseTone.Disappointed,
     responseDelayDays: calculateResponseDelay(relationshipScore),
     isNewsworthy: false,
-    relationshipChange: 0,
-    isUltimatum: shouldUltimatum,
+    relationshipChange: REJECT_RELATIONSHIP_PENALTY,
+    rejectionReason,
+    acceptanceProbability: probs.accept,
   };
 }
 

--- a/src/main/engines/negotiation-engine.ts
+++ b/src/main/engines/negotiation-engine.ts
@@ -346,17 +346,23 @@ function processNegotiation(
   const responseRound = createResponseRound(lastRound, result, input.currentDate);
 
   // Update negotiation
-  // Type assertion needed because Negotiation is a union type with different round types
-  // The cast is safe because responseRound is created from the same negotiation's lastRound
+  // Type assertion needed because Negotiation is a union type with different round types.
+  // The cast is safe because responseRound is created from the same negotiation's lastRound.
   const newPhase = determineNewPhase(result.responseType);
-  const updatedNegotiation = {
+  const baseUpdate = {
     ...negotiation,
     phase: newPhase,
     rounds: [...negotiation.rounds, responseRound],
-    ...(newPhase === NegotiationPhase.Failed && result.rejectionReason
-      ? { rejectionReason: result.rejectionReason }
-      : {}),
   } as Negotiation;
+
+  // rejectionReason only exists on SponsorNegotiation — narrow before assigning
+  // so we don't widen the union to include the field on other negotiation types.
+  const updatedNegotiation: Negotiation =
+    newPhase === NegotiationPhase.Failed &&
+    result.rejectionReason &&
+    baseUpdate.stakeholderType === StakeholderType.Sponsor
+      ? { ...baseUpdate, rejectionReason: result.rejectionReason }
+      : baseUpdate;
 
   // Determine if should stop simulation
   // Always stop for: Accept, Reject (negotiation concluded)

--- a/src/main/engines/negotiation-engine.ts
+++ b/src/main/engines/negotiation-engine.ts
@@ -348,10 +348,14 @@ function processNegotiation(
   // Update negotiation
   // Type assertion needed because Negotiation is a union type with different round types
   // The cast is safe because responseRound is created from the same negotiation's lastRound
+  const newPhase = determineNewPhase(result.responseType);
   const updatedNegotiation = {
     ...negotiation,
-    phase: determineNewPhase(result.responseType),
+    phase: newPhase,
     rounds: [...negotiation.rounds, responseRound],
+    ...(newPhase === NegotiationPhase.Failed && result.rejectionReason
+      ? { rejectionReason: result.rejectionReason }
+      : {}),
   } as Negotiation;
 
   // Determine if should stop simulation

--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -1112,6 +1112,30 @@ export const GameStateManager = {
       generateSponsorSigningEvent(state, result, true);
     }
 
+    // Auto-fail any remaining PendingPlayerConfirmation negotiations for the same tier
+    // if signing this deal filled the last open slot.
+    const nowFilledSlots = state.sponsorDeals.filter(
+      (d) => d.teamId === negotiation.teamId && d.tier === sponsor.tier
+    ).length;
+    if (nowFilledSlots >= SPONSOR_SLOT_COUNTS[sponsor.tier]) {
+      for (const n of state.negotiations) {
+        if (
+          n.id !== negotiationId &&
+          n.stakeholderType === StakeholderType.Sponsor &&
+          n.teamId === negotiation.teamId &&
+          n.phase === NegotiationPhase.PendingPlayerConfirmation
+        ) {
+          const otherSponsor = state.sponsors.find((s) => s.id === (n as SponsorNegotiation).sponsorId);
+          if (otherSponsor?.tier === sponsor.tier) {
+            (n as SponsorNegotiation).phase = NegotiationPhase.Failed;
+            (n as SponsorNegotiation).lastActivityDate = { ...state.currentDate };
+            (n as SponsorNegotiation).rejectionReason =
+              'Your slot was taken by another deal — we\'ve withdrawn.';
+          }
+        }
+      }
+    }
+
     return state;
   },
 

--- a/src/main/services/game-state-manager.ts
+++ b/src/main/services/game-state-manager.ts
@@ -41,6 +41,7 @@ import {
   generateContractSigningHeadline,
   createSponsorContractFromNegotiation,
   generateSponsorSigningEvent,
+  generateNegotiationUpdateEmail,
 } from './contract-creator';
 import type {
   GameState,
@@ -1118,6 +1119,7 @@ export const GameStateManager = {
       (d) => d.teamId === negotiation.teamId && d.tier === sponsor.tier
     ).length;
     if (nowFilledSlots >= SPONSOR_SLOT_COUNTS[sponsor.tier]) {
+      const slotFilledReason = "Your slot was taken by another deal — we've withdrawn.";
       for (const n of state.negotiations) {
         if (
           n.id !== negotiationId &&
@@ -1127,10 +1129,19 @@ export const GameStateManager = {
         ) {
           const otherSponsor = state.sponsors.find((s) => s.id === (n as SponsorNegotiation).sponsorId);
           if (otherSponsor?.tier === sponsor.tier) {
-            (n as SponsorNegotiation).phase = NegotiationPhase.Failed;
-            (n as SponsorNegotiation).lastActivityDate = { ...state.currentDate };
-            (n as SponsorNegotiation).rejectionReason =
-              'Your slot was taken by another deal — we\'ve withdrawn.';
+            const sponsorNeg = n as SponsorNegotiation;
+            sponsorNeg.phase = NegotiationPhase.Failed;
+            sponsorNeg.lastActivityDate = { ...state.currentDate };
+            sponsorNeg.rejectionReason = slotFilledReason;
+
+            // Email the player so the auto-fail is visible without opening the Negotiations tab
+            generateNegotiationUpdateEmail(
+              state,
+              otherSponsor.name,
+              NegotiationPhase.Failed,
+              false,
+              ` ${slotFilledReason}`
+            );
           }
         }
       }

--- a/src/main/services/negotiation-processor.ts
+++ b/src/main/services/negotiation-processor.ts
@@ -244,12 +244,18 @@ export function applyNegotiationUpdates(state: GameState, updates: NegotiationUp
           const sponsor = state.sponsors.find((s) => s.id === sponsorNeg.sponsorId);
           if (sponsor) {
             const latestRound = sponsorNeg.rounds[sponsorNeg.rounds.length - 1];
+            // For failed sponsor negotiations, surface the engine's rejection reason
+            // (set by sponsor-evaluator) so the email matches the History card.
+            const failedSuffix =
+              sponsorNeg.phase === NegotiationPhase.Failed && sponsorNeg.rejectionReason
+                ? ` ${sponsorNeg.rejectionReason}`
+                : ' You may approach other sponsors.';
             generateNegotiationUpdateEmail(
               state,
               sponsor.name,
               sponsorNeg.phase,
               latestRound?.isUltimatum ?? false,
-              ' You may approach other sponsors.'
+              failedSuffix
             );
           }
         }

--- a/src/renderer/content/Deals.tsx
+++ b/src/renderer/content/Deals.tsx
@@ -9,7 +9,6 @@ import { seasonToYear } from '../../shared/utils/date-utils';
 import { IpcChannels } from '../../shared/ipc';
 import {
   SponsorTier,
-  SponsorPlacement,
   NegotiationPhase,
   StakeholderType,
   type Sponsor,
@@ -23,6 +22,9 @@ import {
   getLikelihoodBand,
   getReputationStanding,
   getRequiredPosition,
+  computeReputationRatio,
+  calculateWillingPayment,
+  getPlacementForTier,
   TIER_PAYMENT_RANGES,
   HARD_GATE_MULTIPLIER,
   SOFT_GATE_MULTIPLIER,
@@ -95,18 +97,6 @@ function getIndustryIcon(industry: string): string {
   return INDUSTRY_ICONS[industry] ?? DEFAULT_ICON;
 }
 
-function getPlacementForTier(tier: SponsorTier): SponsorPlacement {
-  switch (tier) {
-    case SponsorTier.Title:
-      return SponsorPlacement.Primary;
-    case SponsorTier.Major:
-      return SponsorPlacement.Secondary;
-    case SponsorTier.Minor:
-    default:
-      return SponsorPlacement.Tertiary;
-  }
-}
-
 /** Return the name of the sponsor causing a rival conflict, or null */
 function getRivalConflictName(
   sponsor: Sponsor,
@@ -119,17 +109,6 @@ function getRivalConflictName(
     if (existing?.rivalGroup === sponsor.rivalGroup) return existing.name;
   }
   return null;
-}
-
-/** Compute reputationRatio for a sponsor given team position data */
-function computeReputationRatio(
-  teamPosition: number,
-  totalTeams: number,
-  minReputation: number
-): number {
-  const positionScore = 1 - (teamPosition - 1) / (totalTeams - 1 || 1);
-  const effectiveReputation = positionScore * 100;
-  return effectiveReputation / (minReputation || 1);
 }
 
 // ===========================================
@@ -320,7 +299,6 @@ function SponsorCard({
 
 interface ContactModalProps {
   sponsor: Sponsor;
-  currentSeason: number;
   teamPosition: number;
   totalTeams: number;
   existingPlayerDeals: ActiveSponsorDeal[];
@@ -331,7 +309,6 @@ interface ContactModalProps {
 
 function ContactModal({
   sponsor,
-  currentSeason,
   teamPosition,
   totalTeams,
   existingPlayerDeals,
@@ -357,23 +334,11 @@ function ContactModal({
       ? "Cannot negotiate: your team's reputation is below this sponsor's requirement"
       : null;
 
-  // Live likelihood band
-  const willingPayment = useMemo(() => {
-    // Approximate willingPayment using the same formula as the evaluator
-    const PREMIUM_REPUTATION_THRESHOLD = 1.2;
-    const MAX_PREMIUM_MULTIPLIER = 1.25;
-    const DISCOUNT_MULTIPLIER_FLOOR = 0.7;
-
-    let willing = sponsor.baseMonthlyPayment;
-    if (reputationRatio >= PREMIUM_REPUTATION_THRESHOLD) {
-      const premiumFactor = Math.min(reputationRatio - 1, MAX_PREMIUM_MULTIPLIER - 1);
-      willing = sponsor.baseMonthlyPayment * (1 + premiumFactor);
-    } else if (reputationRatio < 1.0) {
-      const discountFactor = Math.max(reputationRatio, DISCOUNT_MULTIPLIER_FLOOR);
-      willing = sponsor.baseMonthlyPayment * discountFactor;
-    }
-    return Math.round(willing);
-  }, [sponsor.baseMonthlyPayment, reputationRatio]);
+  // Live likelihood band — uses the engine's own willing-payment + probability functions
+  const willingPayment = useMemo(
+    () => calculateWillingPayment(sponsor, teamPosition, totalTeams),
+    [sponsor, teamPosition, totalTeams]
+  );
 
   const likelihoodBand = useMemo(() => {
     if (hasHardBlocker) return getLikelihoodBand({ accept: 0, counter: 0, reject: 1 });
@@ -391,9 +356,8 @@ function ContactModal({
 
   // Slider ranges
   const maxMonthly = sponsor.baseMonthlyPayment * 3;
-  const stepMonthly = Math.max(1000, Math.round(sponsor.baseMonthlyPayment / 100) * 1000);
   const maxBonus = sponsor.baseMonthlyPayment * 6;
-  const stepBonus = Math.max(1000, Math.round(sponsor.baseMonthlyPayment / 100) * 1000);
+  const sliderStep = Math.max(1000, Math.round(sponsor.baseMonthlyPayment / 100) * 1000);
 
   const handleSubmit = () => {
     onSubmit({
@@ -453,7 +417,7 @@ function ContactModal({
                 type="range"
                 min={0}
                 max={maxMonthly}
-                step={stepMonthly}
+                step={sliderStep}
                 value={monthlyPayment}
                 onChange={(e) => setMonthlyPayment(Number(e.target.value))}
                 className="w-full accent-white"
@@ -469,7 +433,7 @@ function ContactModal({
                 type="range"
                 min={0}
                 max={maxBonus}
-                step={stepBonus}
+                step={sliderStep}
                 value={signingBonus}
                 onChange={(e) => setSigningBonus(Number(e.target.value))}
                 className="w-full accent-white"
@@ -910,7 +874,6 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
     );
   }
 
-  const currentSeason = gameState.currentSeason.seasonNumber;
   const badgeCount = needsAttention.length + sentNegotiations.length;
 
   return (
@@ -1075,7 +1038,6 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
       {contactingSponsor && (
         <ContactModal
           sponsor={contactingSponsor}
-          currentSeason={currentSeason}
           teamPosition={teamPosition}
           totalTeams={totalTeams}
           existingPlayerDeals={playerDealsList}

--- a/src/renderer/content/Deals.tsx
+++ b/src/renderer/content/Deals.tsx
@@ -15,8 +15,18 @@ import {
   type Sponsor,
   type SponsorNegotiation,
   type SponsorContractTerms,
+  type ActiveSponsorDeal,
 } from '../../shared/domain';
 import { SPONSOR_SLOT_COUNTS } from '../../shared/domain/engine-utils';
+import {
+  computeAcceptanceProbabilities,
+  getLikelihoodBand,
+  getReputationStanding,
+  getRequiredPosition,
+  TIER_PAYMENT_RANGES,
+  HARD_GATE_MULTIPLIER,
+  SOFT_GATE_MULTIPLIER,
+} from '../../shared/domain/sponsor-probability';
 
 // ===========================================
 // TYPES
@@ -51,21 +61,21 @@ const DURATION_OPTIONS: DropdownOption<DurationValue>[] = [
 
 /** Industry icons (matches Sponsors.tsx) */
 const INDUSTRY_ICONS: Record<string, string> = {
-  'oil-gas': '\u26FD',
+  'oil-gas': '⛽',
   technology: '\u{1F4BB}',
   finance: '\u{1F4B3}',
   telecommunications: '\u{1F4F1}',
   payments: '\u{1F4B8}',
   'water-technology': '\u{1F4A7}',
   consulting: '\u{1F4BC}',
-  aviation: '\u2708\uFE0F',
+  aviation: '✈️',
   luxury: '\u{1F48E}',
   beverages: '\u{1F37A}',
   logistics: '\u{1F4E6}',
   apparel: '\u{1F455}',
-  insurance: '\u{1F6E1}\uFE0F',
+  insurance: '\u{1F6E1}️',
   tyres: '\u{1F6DE}',
-  components: '\u2699\uFE0F',
+  components: '⚙️',
   'consumer-electronics': '\u{1F4F7}',
   entertainment: '\u{1F3AC}',
   hospitality: '\u{1F3E8}',
@@ -95,6 +105,31 @@ function getPlacementForTier(tier: SponsorTier): SponsorPlacement {
     default:
       return SponsorPlacement.Tertiary;
   }
+}
+
+/** Return the name of the sponsor causing a rival conflict, or null */
+function getRivalConflictName(
+  sponsor: Sponsor,
+  playerDealsForSponsor: ActiveSponsorDeal[],
+  allSponsors: Sponsor[]
+): string | null {
+  if (!sponsor.rivalGroup) return null;
+  for (const deal of playerDealsForSponsor) {
+    const existing = allSponsors.find((s) => s.id === deal.sponsorId);
+    if (existing?.rivalGroup === sponsor.rivalGroup) return existing.name;
+  }
+  return null;
+}
+
+/** Compute reputationRatio for a sponsor given team position data */
+function computeReputationRatio(
+  teamPosition: number,
+  totalTeams: number,
+  minReputation: number
+): number {
+  const positionScore = 1 - (teamPosition - 1) / (totalTeams - 1 || 1);
+  const effectiveReputation = positionScore * 100;
+  return effectiveReputation / (minReputation || 1);
 }
 
 // ===========================================
@@ -131,19 +166,112 @@ function SponsorLogo({ sponsor, size }: SponsorLogoProps) {
   );
 }
 
+// ===========================================
+// REPUTATION STANDING BADGE
+// ===========================================
+
+const REP_STANDING_STYLES = {
+  'Strong match': 'bg-emerald-900/40 text-emerald-400 border border-emerald-700/50',
+  'Borderline': 'bg-amber-900/40 text-amber-400 border border-amber-700/50',
+  'Below requirements': 'bg-red-900/40 text-red-400 border border-red-700/50',
+} as const;
+
+function RepStandingBadge({ standing }: { standing: ReturnType<typeof getReputationStanding> }) {
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded font-medium ${REP_STANDING_STYLES[standing]}`}>
+      {standing}
+    </span>
+  );
+}
+
+// ===========================================
+// LIKELIHOOD BAND INDICATOR
+// ===========================================
+
+const BAND_STYLES = {
+  'Likely to accept': { text: 'text-emerald-400', label: 'Likely to accept' },
+  'Likely to counter': { text: 'text-amber-400', label: 'Likely to counter' },
+  'Toss-up': { text: 'text-blue-400', label: 'Toss-up' },
+  'Likely to reject': { text: 'text-red-400', label: 'Likely to reject' },
+} as const;
+
+function LikelihoodBandIndicator({ band }: { band: ReturnType<typeof getLikelihoodBand> }) {
+  const style = BAND_STYLES[band];
+  return (
+    <div className="flex items-center justify-between px-3 py-2 bg-neutral-800/60 border border-neutral-700 rounded">
+      <span className="text-xs text-muted">Likelihood of acceptance</span>
+      <span className={`text-sm font-semibold ${style.text}`}>{style.label}</span>
+    </div>
+  );
+}
+
+// ===========================================
+// SPONSOR CARD
+// ===========================================
+
 interface SponsorCardProps {
   sponsor: Sponsor;
   isContracted: boolean;
   isNegotiating: boolean;
   isSlotFull: boolean;
+  rivalConflictName: string | null;
+  isBelowRepFloor: boolean;
+  repStanding: ReturnType<typeof getReputationStanding>;
+  negotiationId: string | null;
   onContact: () => void;
+  onViewNegotiations: () => void;
 }
 
-function SponsorCard({ sponsor, isContracted, isNegotiating, isSlotFull, onContact }: SponsorCardProps) {
+function SponsorCard({
+  sponsor,
+  isContracted,
+  isNegotiating,
+  isSlotFull,
+  rivalConflictName,
+  isBelowRepFloor,
+  repStanding,
+  negotiationId,
+  onContact,
+  onViewNegotiations,
+}: SponsorCardProps) {
+  const hasHardBlocker = isSlotFull || rivalConflictName !== null || isBelowRepFloor;
+
+  const blockerReason =
+    rivalConflictName !== null
+      ? `Conflicts with ${rivalConflictName}`
+      : isBelowRepFloor
+      ? 'Below reputation requirement'
+      : isSlotFull
+      ? 'Slot at capacity'
+      : null;
+
   const renderCTA = () => {
     if (isContracted) return <span className="text-sm text-emerald-400">Contracted</span>;
-    if (isNegotiating) return <span className="text-sm text-amber-400">Negotiating</span>;
-    if (isSlotFull) return <span className="text-sm text-neutral-500">Slot full.</span>;
+
+    if (isNegotiating && negotiationId) {
+      return (
+        <button
+          type="button"
+          onClick={onViewNegotiations}
+          className={`btn cursor-pointer px-4 py-2 text-sm font-medium ${GHOST_BORDERED_BUTTON_CLASSES}`}
+        >
+          View in Negotiations
+        </button>
+      );
+    }
+
+    if (hasHardBlocker) {
+      return (
+        <button
+          type="button"
+          disabled
+          className="btn px-4 py-2 text-sm font-medium opacity-40 cursor-not-allowed border border-neutral-600 text-neutral-500"
+        >
+          Contact
+        </button>
+      );
+    }
+
     return (
       <button
         type="button"
@@ -161,16 +289,22 @@ function SponsorCard({ sponsor, isContracted, isNegotiating, isSlotFull, onConta
       <SponsorLogo sponsor={sponsor} size="md" />
 
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
           <h3 className="font-semibold text-primary truncate">{sponsor.name}</h3>
           <span className="text-xs px-2 py-0.5 rounded bg-neutral-700 text-muted">
             {SPONSOR_TIER_LABELS[sponsor.tier]}
           </span>
+          <RepStandingBadge standing={repStanding} />
+          {rivalConflictName !== null && (
+            <span className="text-xs px-2 py-0.5 rounded bg-amber-900/40 text-amber-400 border border-amber-700/50 font-medium">
+              Rival conflict
+            </span>
+          )}
         </div>
-        <p className="text-sm text-muted capitalize">{sponsor.industry.replace(/-/g, ' ')}</p>
-        <p className="text-sm text-secondary mt-1">
-          Base: {formatCurrency(sponsor.baseMonthlyPayment)}/mo
-        </p>
+        <p className="text-sm text-muted capitalize mt-0.5">{sponsor.industry.replace(/-/g, ' ')}</p>
+        {blockerReason && (
+          <p className="text-xs text-red-400 mt-1 italic">{blockerReason}</p>
+        )}
       </div>
 
       <div className="flex-shrink-0">
@@ -180,17 +314,86 @@ function SponsorCard({ sponsor, isContracted, isNegotiating, isSlotFull, onConta
   );
 }
 
+// ===========================================
+// CONTACT MODAL
+// ===========================================
+
 interface ContactModalProps {
   sponsor: Sponsor;
   currentSeason: number;
+  teamPosition: number;
+  totalTeams: number;
+  existingPlayerDeals: ActiveSponsorDeal[];
+  allSponsors: Sponsor[];
   onClose: () => void;
   onSubmit: (terms: SponsorContractTerms) => void;
 }
 
-function ContactModal({ sponsor, currentSeason, onClose, onSubmit }: ContactModalProps) {
+function ContactModal({
+  sponsor,
+  currentSeason,
+  teamPosition,
+  totalTeams,
+  existingPlayerDeals,
+  allSponsors,
+  onClose,
+  onSubmit,
+}: ContactModalProps) {
   const [duration, setDuration] = useState<DurationValue>('2');
   const [monthlyPayment, setMonthlyPayment] = useState(sponsor.baseMonthlyPayment);
   const [signingBonus, setSigningBonus] = useState(Math.round(sponsor.baseMonthlyPayment * 2));
+
+  // Hard blocker checks
+  const rivalConflictName = getRivalConflictName(sponsor, existingPlayerDeals, allSponsors);
+  const reputationRatio = computeReputationRatio(teamPosition, totalTeams, sponsor.minReputation);
+  const isBelowHardGate = reputationRatio < HARD_GATE_MULTIPLIER;
+  const isBelowSoftGate = reputationRatio < SOFT_GATE_MULTIPLIER;
+  const hasHardBlocker = rivalConflictName !== null || isBelowHardGate;
+
+  const blockerMessage =
+    rivalConflictName !== null
+      ? `Cannot negotiate: rival group conflict with ${rivalConflictName}`
+      : isBelowHardGate
+      ? "Cannot negotiate: your team's reputation is below this sponsor's requirement"
+      : null;
+
+  // Live likelihood band
+  const willingPayment = useMemo(() => {
+    // Approximate willingPayment using the same formula as the evaluator
+    const PREMIUM_REPUTATION_THRESHOLD = 1.2;
+    const MAX_PREMIUM_MULTIPLIER = 1.25;
+    const DISCOUNT_MULTIPLIER_FLOOR = 0.7;
+
+    let willing = sponsor.baseMonthlyPayment;
+    if (reputationRatio >= PREMIUM_REPUTATION_THRESHOLD) {
+      const premiumFactor = Math.min(reputationRatio - 1, MAX_PREMIUM_MULTIPLIER - 1);
+      willing = sponsor.baseMonthlyPayment * (1 + premiumFactor);
+    } else if (reputationRatio < 1.0) {
+      const discountFactor = Math.max(reputationRatio, DISCOUNT_MULTIPLIER_FLOOR);
+      willing = sponsor.baseMonthlyPayment * discountFactor;
+    }
+    return Math.round(willing);
+  }, [sponsor.baseMonthlyPayment, reputationRatio]);
+
+  const likelihoodBand = useMemo(() => {
+    if (hasHardBlocker) return getLikelihoodBand({ accept: 0, counter: 0, reject: 1 });
+    const paymentRatio = monthlyPayment / willingPayment;
+    const probs = computeAcceptanceProbabilities(paymentRatio, isBelowHardGate, isBelowSoftGate);
+    return getLikelihoodBand(probs);
+  }, [monthlyPayment, willingPayment, isBelowHardGate, isBelowSoftGate, hasHardBlocker]);
+
+  // Reference line
+  const tierRange = TIER_PAYMENT_RANGES[sponsor.tier];
+
+  // Requirements blurb
+  const requiredPosition = getRequiredPosition(totalTeams, sponsor.minReputation);
+  const requirementsBlurb = `Requires top-${requiredPosition} championship finish`;
+
+  // Slider ranges
+  const maxMonthly = sponsor.baseMonthlyPayment * 3;
+  const stepMonthly = Math.max(1000, Math.round(sponsor.baseMonthlyPayment / 100) * 1000);
+  const maxBonus = sponsor.baseMonthlyPayment * 6;
+  const stepBonus = Math.max(1000, Math.round(sponsor.baseMonthlyPayment / 100) * 1000);
 
   const handleSubmit = () => {
     onSubmit({
@@ -203,60 +406,89 @@ function ContactModal({ sponsor, currentSeason, onClose, onSubmit }: ContactModa
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-      <div className="card p-6 max-w-md w-full mx-4" style={ACCENT_CARD_STYLE}>
-        <h2 className="text-xl font-bold text-primary mb-4">Contact {sponsor.name}</h2>
-
-        <div className="flex items-center gap-3 mb-6">
+      <div className="card max-w-md w-full mx-4" style={ACCENT_CARD_STYLE}>
+        {/* Modal header */}
+        <div className="flex items-start gap-3 p-5 border-b border-neutral-700">
           <SponsorLogo sponsor={sponsor} size="md" />
-          <div>
-            <p className="text-sm text-muted capitalize">{sponsor.industry.replace(/-/g, ' ')}</p>
-            <p className="text-xs text-secondary">{SPONSOR_TIER_LABELS[sponsor.tier]} Sponsor</p>
-          </div>
-        </div>
-
-        <p className="text-sm text-muted mb-4">
-          Propose contract terms for {seasonToYear(currentSeason + 1)} season.
-        </p>
-
-        <div className="space-y-4">
-          <div>
-            <label className="block text-sm text-secondary mb-1">Monthly Payment</label>
-            <input
-              type="number"
-              value={monthlyPayment}
-              onChange={(e) => setMonthlyPayment(Number(e.target.value))}
-              className="w-full bg-neutral-800 border border-neutral-600 rounded-lg px-3 py-2 text-primary"
-              min={0}
-              step={10000}
-            />
-            <p className="text-xs text-muted mt-1">
-              Base rate: {formatCurrency(sponsor.baseMonthlyPayment)}/mo
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-bold text-primary leading-tight">{sponsor.name}</h2>
+            <p className="text-xs text-muted mt-0.5">
+              {SPONSOR_TIER_LABELS[sponsor.tier]} Sponsor · {requirementsBlurb}
             </p>
           </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted hover:text-primary text-xl leading-none flex-shrink-0 mt-0.5"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
 
-          <div>
-            <label className="block text-sm text-secondary mb-1">Signing Bonus</label>
-            <input
-              type="number"
-              value={signingBonus}
-              onChange={(e) => setSigningBonus(Number(e.target.value))}
-              className="w-full bg-neutral-800 border border-neutral-600 rounded-lg px-3 py-2 text-primary"
-              min={0}
-              step={10000}
-            />
+        <div className="p-5 space-y-4">
+          {/* Hard blocker */}
+          {hasHardBlocker && blockerMessage && (
+            <div className="px-3 py-2 bg-red-900/30 border border-red-700/50 rounded text-sm text-red-400 font-medium">
+              {blockerMessage}
+            </div>
+          )}
+
+          {/* Likelihood band */}
+          {!hasHardBlocker && <LikelihoodBandIndicator band={likelihoodBand} />}
+
+          {/* Reference line */}
+          <div className="text-xs text-muted italic border-l-2 border-neutral-600 pl-2">
+            Sponsors of this tier typically pay {formatCurrency(tierRange.low)}–{formatCurrency(tierRange.high)}/mo
           </div>
 
-          <div>
-            <label className="block text-sm text-secondary mb-1">Duration</label>
-            <Dropdown<DurationValue>
-              options={DURATION_OPTIONS}
-              value={duration}
-              onChange={setDuration}
-            />
+          {/* Sliders */}
+          <div className={hasHardBlocker ? 'opacity-40 pointer-events-none space-y-4' : 'space-y-4'}>
+            <div>
+              <div className="flex justify-between text-sm mb-1">
+                <label className="text-secondary font-medium">Monthly Payment</label>
+                <span className="text-primary font-medium">{formatCurrency(monthlyPayment)}</span>
+              </div>
+              <input
+                type="range"
+                min={0}
+                max={maxMonthly}
+                step={stepMonthly}
+                value={monthlyPayment}
+                onChange={(e) => setMonthlyPayment(Number(e.target.value))}
+                className="w-full accent-white"
+              />
+            </div>
+
+            <div>
+              <div className="flex justify-between text-sm mb-1">
+                <label className="text-secondary font-medium">Signing Bonus</label>
+                <span className="text-primary font-medium">{formatCurrency(signingBonus)}</span>
+              </div>
+              <input
+                type="range"
+                min={0}
+                max={maxBonus}
+                step={stepBonus}
+                value={signingBonus}
+                onChange={(e) => setSigningBonus(Number(e.target.value))}
+                className="w-full accent-white"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm text-secondary font-medium mb-1">Duration</label>
+              <Dropdown<DurationValue>
+                options={DURATION_OPTIONS}
+                value={duration}
+                onChange={setDuration}
+              />
+            </div>
           </div>
         </div>
 
-        <div className="flex gap-3 mt-6">
+        {/* Footer */}
+        <div className="flex gap-3 px-5 pb-5">
           <button
             type="button"
             onClick={onClose}
@@ -267,16 +499,21 @@ function ContactModal({ sponsor, currentSeason, onClose, onSubmit }: ContactModa
           <button
             type="button"
             onClick={handleSubmit}
-            className="btn cursor-pointer flex-1 px-4 py-2 font-medium"
-            style={ACCENT_BORDERED_BUTTON_STYLE}
+            disabled={hasHardBlocker}
+            className={`btn flex-1 px-4 py-2 font-medium ${hasHardBlocker ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`}
+            style={hasHardBlocker ? undefined : ACCENT_BORDERED_BUTTON_STYLE}
           >
-            Send Proposal
+            Submit Proposal
           </button>
         </div>
       </div>
     </div>
   );
 }
+
+// ===========================================
+// NEGOTIATION CARD
+// ===========================================
 
 interface NegotiationCardProps {
   negotiation: SponsorNegotiation;
@@ -332,10 +569,11 @@ function NegotiationCard({ negotiation, sponsor, isSlotFilled = false, onAccept,
         </div>
       </div>
 
-      {terms && !isComplete && !isFailed && (
+      {terms && !isComplete && (
         <div className="mt-4 pt-4 border-t border-neutral-700">
           <h4 className="text-sm font-medium text-secondary mb-2">
             {isPendingConfirmation ? 'Accepted Terms' :
+             isFailed ? 'Last Offer' :
              lastRound?.offeredBy === 'player' ? 'Your Offer' : 'Their Offer'}
           </h4>
           <div className="grid grid-cols-3 gap-4 text-sm">
@@ -407,14 +645,22 @@ function NegotiationCard({ negotiation, sponsor, isSlotFilled = false, onAccept,
 
       {isFailed && (
         <div className="mt-4 p-3 bg-red-900/20 border border-red-600/30 rounded-lg">
-          <p className="text-sm text-red-400 text-center">
-            Negotiation ended without agreement.
-          </p>
+          {negotiation.rejectionReason ? (
+            <p className="text-sm text-red-300 italic">"{negotiation.rejectionReason}"</p>
+          ) : (
+            <p className="text-sm text-red-400 text-center">
+              Negotiation ended without agreement.
+            </p>
+          )}
         </div>
       )}
     </div>
   );
 }
+
+// ===========================================
+// SECTION HEADER
+// ===========================================
 
 interface SectionHeaderProps {
   title: string;
@@ -440,6 +686,10 @@ function SectionHeader({ title, count, collapsible, collapsed, onToggle }: Secti
     </div>
   );
 }
+
+// ===========================================
+// TOAST
+// ===========================================
 
 interface ToastProps {
   message: string;
@@ -507,6 +757,11 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
     );
   }, [gameState]);
 
+  const playerDealsList = useMemo(() => {
+    if (!gameState) return [] as ActiveSponsorDeal[];
+    return gameState.sponsorDeals.filter((d) => d.teamId === gameState.player.teamId);
+  }, [gameState]);
+
   // All player sponsor negotiations
   const allNegotiations = useMemo(() => {
     if (!gameState) return [];
@@ -532,13 +787,15 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
       (n) => n.phase === NegotiationPhase.Failed || n.phase === NegotiationPhase.Completed
     ), [allNegotiations]);
 
-  // Active (non-terminal) negotiations for browse-tab state
-  const negotiatingSponsorIds = useMemo(() => {
-    return new Set(
-      allNegotiations
-        .filter((n) => n.phase !== NegotiationPhase.Completed && n.phase !== NegotiationPhase.Failed)
-        .map((n) => n.sponsorId)
-    );
+  // Active (non-terminal) negotiations for browse-tab state, keyed by sponsorId
+  const activeNegotiationBySponsorId = useMemo(() => {
+    const map = new Map<string, SponsorNegotiation>();
+    for (const n of allNegotiations) {
+      if (n.phase !== NegotiationPhase.Completed && n.phase !== NegotiationPhase.Failed) {
+        map.set(n.sponsorId, n);
+      }
+    }
+    return map;
   }, [allNegotiations]);
 
   // Slot fullness per tier (active deals count)
@@ -554,6 +811,23 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
     }
     return result;
   }, [gameState]);
+
+  // Team position and total teams (for reputation calculations)
+  const { teamPosition, totalTeams } = useMemo(() => {
+    if (!gameState) return { teamPosition: 1, totalTeams: 10 };
+    const standings = gameState.currentSeason.constructorStandings;
+    const standing = standings.find((s) => s.teamId === gameState.player.teamId);
+    return {
+      teamPosition: standing?.position ?? standings.length,
+      totalTeams: Math.max(standings.length, 1),
+    };
+  }, [gameState]);
+
+  // Navigate to negotiations tab (for "View in Negotiations" button)
+  const handleViewNegotiations = useCallback(() => {
+    setActiveTab('negotiations');
+    setHistoryCollapsed(false);
+  }, []);
 
   // Filter sponsors for browse tab
   const filteredSponsors = useMemo(() => {
@@ -679,16 +953,35 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
           </div>
 
           <div className="space-y-3">
-            {filteredSponsors.map((sponsor) => (
-              <SponsorCard
-                key={sponsor.id}
-                sponsor={sponsor}
-                isContracted={playerDeals.has(sponsor.id)}
-                isNegotiating={negotiatingSponsorIds.has(sponsor.id)}
-                isSlotFull={!playerDeals.has(sponsor.id) && !negotiatingSponsorIds.has(sponsor.id) && tierSlotsFull[sponsor.tier]}
-                onContact={() => setContactingSponsor(sponsor)}
-              />
-            ))}
+            {filteredSponsors.map((sponsor) => {
+              const isContracted = playerDeals.has(sponsor.id);
+              const activeNeg = activeNegotiationBySponsorId.get(sponsor.id) ?? null;
+              const isNegotiating = activeNeg !== null;
+              const isSlotFull =
+                !isContracted && !isNegotiating && tierSlotsFull[sponsor.tier];
+              const rivalConflictName = isContracted
+                ? null
+                : getRivalConflictName(sponsor, playerDealsList, gameState.sponsors);
+              const repStanding = getReputationStanding(teamPosition, totalTeams, sponsor.minReputation);
+              const repRatio = computeReputationRatio(teamPosition, totalTeams, sponsor.minReputation);
+              const isBelowRepFloor = !isContracted && repRatio < HARD_GATE_MULTIPLIER;
+
+              return (
+                <SponsorCard
+                  key={sponsor.id}
+                  sponsor={sponsor}
+                  isContracted={isContracted}
+                  isNegotiating={isNegotiating}
+                  isSlotFull={isSlotFull}
+                  rivalConflictName={rivalConflictName}
+                  isBelowRepFloor={isBelowRepFloor}
+                  repStanding={repStanding}
+                  negotiationId={activeNeg?.id ?? null}
+                  onContact={() => setContactingSponsor(sponsor)}
+                  onViewNegotiations={handleViewNegotiations}
+                />
+              );
+            })}
             {filteredSponsors.length === 0 && (
               <p className="text-center text-muted py-8">
                 No sponsors found matching filter.
@@ -783,6 +1076,10 @@ export function Deals({ embedded = false, initialTierFilter }: DealsProps) {
         <ContactModal
           sponsor={contactingSponsor}
           currentSeason={currentSeason}
+          teamPosition={teamPosition}
+          totalTeams={totalTeams}
+          existingPlayerDeals={playerDealsList}
+          allSponsors={gameState.sponsors}
           onClose={() => setContactingSponsor(null)}
           onSubmit={handleStartNegotiation}
         />

--- a/src/shared/domain/engines.ts
+++ b/src/shared/domain/engines.ts
@@ -672,6 +672,12 @@ export interface NegotiationEvaluationResult {
 
   /** If true, this is a "take it or leave it" final offer - no more counters allowed */
   isUltimatum?: boolean;
+
+  /** Human-readable rejection reason (populated when responseType is Reject) */
+  rejectionReason?: string;
+
+  /** Probability of acceptance at the time of evaluation (0–1) */
+  acceptanceProbability?: number;
 }
 
 /**

--- a/src/shared/domain/sponsor-probability.ts
+++ b/src/shared/domain/sponsor-probability.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared sponsor probability utilities.
+ * Used by both the engine (main) and the renderer (UI live band).
+ */
+
+import { SponsorTier } from './types';
+
+// =============================================================================
+// THRESHOLD CONSTANTS (shared with sponsor-evaluator.ts)
+// =============================================================================
+
+export const INSTANT_ACCEPT_RATIO = 0.95;
+export const REJECT_RATIO = 0.6;
+export const SOFT_GATE_MULTIPLIER = 0.9;
+export const HARD_GATE_MULTIPLIER = 0.7;
+
+// =============================================================================
+// TIER PAYMENT RANGES (hardcoded from sponsors.json data)
+// =============================================================================
+
+export const TIER_PAYMENT_RANGES: Record<SponsorTier, { low: number; high: number }> = {
+  [SponsorTier.Title]: { low: 2_916_667, high: 5_000_000 },
+  [SponsorTier.Major]: { low: 1_000_000, high: 2_083_333 },
+  [SponsorTier.Minor]: { low: 166_667, high: 666_667 },
+};
+
+// =============================================================================
+// SEEDED RNG
+// =============================================================================
+
+/** djb2 hash — produces a stable uint32 from any string */
+export function hashString(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash) ^ str.charCodeAt(i);
+  }
+  return hash >>> 0;
+}
+
+/** Mulberry32 PRNG — returns a float in [0, 1) from a uint32 seed */
+export function seededRandom(seed: number): number {
+  let t = (seed + 0x6d2b79f5) >>> 0;
+  t = Math.imul(t ^ (t >>> 15), t | 1);
+  t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+// =============================================================================
+// PROBABILITY MODEL
+// =============================================================================
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
+
+const PROB_STEEPNESS = 25;
+
+export interface AcceptanceProbabilities {
+  accept: number;
+  counter: number;
+  reject: number;
+}
+
+/**
+ * Compute the probability distribution over Accept / Counter / Reject outcomes
+ * for a given offer state. Pure function — no side effects.
+ *
+ * @param paymentRatio  offeredPayment / willingPayment
+ * @param isBelowHardGate  reputationRatio < HARD_GATE_MULTIPLIER
+ * @param isBelowSoftGate  reputationRatio < SOFT_GATE_MULTIPLIER
+ */
+export function computeAcceptanceProbabilities(
+  paymentRatio: number,
+  isBelowHardGate: boolean,
+  isBelowSoftGate: boolean
+): AcceptanceProbabilities {
+  if (isBelowHardGate) {
+    return { accept: 0, counter: 0, reject: 1 };
+  }
+
+  let pAccept = sigmoid((paymentRatio - INSTANT_ACCEPT_RATIO) * PROB_STEEPNESS);
+  const pReject = sigmoid((REJECT_RATIO - paymentRatio) * PROB_STEEPNESS);
+
+  // Soft gate heavily dampens acceptance
+  if (isBelowSoftGate) {
+    pAccept *= 0.3;
+  }
+
+  const pCounter = Math.max(0, 1 - pAccept - pReject);
+  return { accept: pAccept, counter: pCounter, reject: pReject };
+}
+
+// =============================================================================
+// LIKELIHOOD BAND
+// =============================================================================
+
+export type LikelihoodBand =
+  | 'Likely to accept'
+  | 'Likely to counter'
+  | 'Toss-up'
+  | 'Likely to reject';
+
+/**
+ * Map a probability distribution to a human-readable likelihood band.
+ * The dominant outcome wins; if no outcome exceeds 50%, it's a Toss-up.
+ */
+export function getLikelihoodBand(probs: AcceptanceProbabilities): LikelihoodBand {
+  const { accept, counter, reject } = probs;
+  if (accept > 0.5) return 'Likely to accept';
+  if (reject > 0.5) return 'Likely to reject';
+  if (counter > 0.5) return 'Likely to counter';
+  return 'Toss-up';
+}
+
+// =============================================================================
+// REPUTATION STANDING
+// =============================================================================
+
+export type ReputationStanding = 'Strong match' | 'Borderline' | 'Below requirements';
+
+/**
+ * Compute the player's reputation standing relative to a sponsor's requirements.
+ *
+ * @param teamPosition  1-indexed constructor standings position
+ * @param totalTeams    number of teams in the championship
+ * @param minReputation sponsor.minReputation (0–100)
+ */
+export function getReputationStanding(
+  teamPosition: number,
+  totalTeams: number,
+  minReputation: number
+): ReputationStanding {
+  const positionScore = 1 - (teamPosition - 1) / (totalTeams - 1 || 1);
+  const effectiveReputation = positionScore * 100;
+  const reputationRatio = effectiveReputation / (minReputation || 1);
+
+  if (reputationRatio < HARD_GATE_MULTIPLIER) return 'Below requirements';
+  if (reputationRatio < SOFT_GATE_MULTIPLIER) return 'Borderline';
+  return 'Strong match';
+}
+
+/**
+ * Compute the minimum constructor championship position required for a sponsor.
+ * Returns the ceiling of the computed position bound.
+ */
+export function getRequiredPosition(totalTeams: number, minReputation: number): number {
+  // Solve: positionScore = minReputation / 100
+  // positionScore = 1 - (position - 1) / (totalTeams - 1)
+  // position = 1 + (totalTeams - 1) * (1 - minReputation / 100)
+  return Math.ceil(1 + (totalTeams - 1) * (1 - minReputation / 100));
+}

--- a/src/shared/domain/sponsor-probability.ts
+++ b/src/shared/domain/sponsor-probability.ts
@@ -1,9 +1,12 @@
 /**
  * Shared sponsor probability utilities.
  * Used by both the engine (main) and the renderer (UI live band).
+ *
+ * All probability + valuation math lives here so the renderer's live likelihood
+ * band reflects the engine's actual decision — no parallel calculation.
  */
 
-import { SponsorTier } from './types';
+import { SponsorTier, SponsorPlacement, type Sponsor } from './types';
 
 // =============================================================================
 // THRESHOLD CONSTANTS (shared with sponsor-evaluator.ts)
@@ -13,6 +16,26 @@ export const INSTANT_ACCEPT_RATIO = 0.95;
 export const REJECT_RATIO = 0.6;
 export const SOFT_GATE_MULTIPLIER = 0.9;
 export const HARD_GATE_MULTIPLIER = 0.7;
+
+// =============================================================================
+// VALUATION CONSTANTS (shared with sponsor-evaluator.ts)
+// =============================================================================
+
+/** Premium multiplier applies when team's reputation exceeds the threshold */
+export const PREMIUM_REPUTATION_THRESHOLD = 1.2;
+/** Cap on the premium uplift over base monthly payment */
+export const MAX_PREMIUM_MULTIPLIER = 1.25;
+/** Floor on the discount multiplier when reputation is below 1.0 */
+export const DISCOUNT_MULTIPLIER_FLOOR = 0.7;
+
+// =============================================================================
+// PROBABILITY-MODEL TUNING CONSTANTS
+// =============================================================================
+
+/** Sigmoid steepness around the accept/reject thresholds */
+const PROB_STEEPNESS = 25;
+/** When team is below soft gate, multiply pAccept by this dampener */
+const SOFT_GATE_PACCEPT_DAMPING = 0.3;
 
 // =============================================================================
 // TIER PAYMENT RANGES (hardcoded from sponsors.json data)
@@ -46,14 +69,58 @@ export function seededRandom(seed: number): number {
 }
 
 // =============================================================================
+// REPUTATION RATIO
+// =============================================================================
+
+/**
+ * Compute reputationRatio = effectiveReputation / minReputation.
+ * effectiveReputation is derived from constructor standings position.
+ */
+export function computeReputationRatio(
+  teamPosition: number,
+  totalTeams: number,
+  minReputation: number
+): number {
+  const positionScore = 1 - (teamPosition - 1) / (totalTeams - 1 || 1);
+  const effectiveReputation = positionScore * 100;
+  return effectiveReputation / (minReputation || 1);
+}
+
+// =============================================================================
+// WILLING PAYMENT
+// =============================================================================
+
+/**
+ * Compute the sponsor's willing monthly payment for a given team.
+ * Premium uplift above PREMIUM_REPUTATION_THRESHOLD; discount below 1.0
+ * (floored at DISCOUNT_MULTIPLIER_FLOOR). This is the divisor used for
+ * paymentRatio in the probability model.
+ */
+export function calculateWillingPayment(
+  sponsor: Sponsor,
+  teamPosition: number,
+  totalTeams: number
+): number {
+  const reputationRatio = computeReputationRatio(teamPosition, totalTeams, sponsor.minReputation);
+
+  let willing = sponsor.baseMonthlyPayment;
+  if (reputationRatio >= PREMIUM_REPUTATION_THRESHOLD) {
+    const premiumFactor = Math.min(reputationRatio - 1, MAX_PREMIUM_MULTIPLIER - 1);
+    willing = sponsor.baseMonthlyPayment * (1 + premiumFactor);
+  } else if (reputationRatio < 1.0) {
+    const discountFactor = Math.max(reputationRatio, DISCOUNT_MULTIPLIER_FLOOR);
+    willing = sponsor.baseMonthlyPayment * discountFactor;
+  }
+  return Math.round(willing);
+}
+
+// =============================================================================
 // PROBABILITY MODEL
 // =============================================================================
 
 function sigmoid(x: number): number {
   return 1 / (1 + Math.exp(-x));
 }
-
-const PROB_STEEPNESS = 25;
 
 export interface AcceptanceProbabilities {
   accept: number;
@@ -81,9 +148,8 @@ export function computeAcceptanceProbabilities(
   let pAccept = sigmoid((paymentRatio - INSTANT_ACCEPT_RATIO) * PROB_STEEPNESS);
   const pReject = sigmoid((REJECT_RATIO - paymentRatio) * PROB_STEEPNESS);
 
-  // Soft gate heavily dampens acceptance
   if (isBelowSoftGate) {
-    pAccept *= 0.3;
+    pAccept *= SOFT_GATE_PACCEPT_DAMPING;
   }
 
   const pCounter = Math.max(0, 1 - pAccept - pReject);
@@ -130,10 +196,7 @@ export function getReputationStanding(
   totalTeams: number,
   minReputation: number
 ): ReputationStanding {
-  const positionScore = 1 - (teamPosition - 1) / (totalTeams - 1 || 1);
-  const effectiveReputation = positionScore * 100;
-  const reputationRatio = effectiveReputation / (minReputation || 1);
-
+  const reputationRatio = computeReputationRatio(teamPosition, totalTeams, minReputation);
   if (reputationRatio < HARD_GATE_MULTIPLIER) return 'Below requirements';
   if (reputationRatio < SOFT_GATE_MULTIPLIER) return 'Borderline';
   return 'Strong match';
@@ -148,4 +211,21 @@ export function getRequiredPosition(totalTeams: number, minReputation: number): 
   // positionScore = 1 - (position - 1) / (totalTeams - 1)
   // position = 1 + (totalTeams - 1) * (1 - minReputation / 100)
   return Math.ceil(1 + (totalTeams - 1) * (1 - minReputation / 100));
+}
+
+// =============================================================================
+// PLACEMENT MAPPING
+// =============================================================================
+
+/** Map sponsor tier to its corresponding placement level on the car. */
+export function getPlacementForTier(tier: SponsorTier): SponsorPlacement {
+  switch (tier) {
+    case SponsorTier.Title:
+      return SponsorPlacement.Primary;
+    case SponsorTier.Major:
+      return SponsorPlacement.Secondary;
+    case SponsorTier.Minor:
+    default:
+      return SponsorPlacement.Tertiary;
+  }
 }

--- a/src/shared/domain/types.ts
+++ b/src/shared/domain/types.ts
@@ -1656,6 +1656,8 @@ export interface SponsorNegotiation extends BaseNegotiation<SponsorContractTerms
   stakeholderType: StakeholderType.Sponsor;
   /** ID of the sponsor being negotiated with */
   sponsorId: string;
+  /** Human-readable reason the negotiation failed (populated on phase = Failed) */
+  rejectionReason?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Probability engine:** `evaluateSponsorOffer` now computes a continuous Accept/Counter/Reject probability using sigmoid curves over `paymentRatio` and reputation gates. A seeded RNG (Mulberry32, seed derived from `negotiation.id + roundNumber`) rolls the outcome so the same offer to the same sponsor always produces the same result within a session.
- **Rejection reasons:** All five rejection paths are populated — rival conflict, below reputation floor, offer too low (with hint range), max rounds, and slot filled by other deal. Stored on `SponsorNegotiation.rejectionReason` when the phase transitions to Failed.
- **Auto-fail on Sign:** When `signSponsorDeal` fills the last open slot, all remaining `PendingPlayerConfirmation` negotiations for that tier are auto-failed with the "slot filled" reason.
- **Browse tab signals:** Each sponsor row shows a `Strong match / Borderline / Below requirements` reputation standing badge and a `Rival conflict` badge. The Contact button is disabled inline for hard blockers (rival, below floor, slot full). An active negotiation shows `View in Negotiations` ghost button instead of Contact.
- **Contact modal:** Header now shows sponsor logo, name, tier, and a computed requirements blurb ("Requires top-N championship finish"). Live likelihood band (`Likely to accept / Likely to counter / Toss-up / Likely to reject`) updates as the monthly payment slider moves. Reference line shows tier payment range. Hard blocker state disables sliders and Submit with a reason message.
- **History cards:** Failed negotiation cards show the rejection reason in quotes.
- **Shared probability module:** `src/shared/domain/sponsor-probability.ts` — pure functions callable from both engine and renderer with no IPC round-trip.
- **CLI test surface:** `scripts/sim-sponsor-tier2.ts` — three scenarios: `band` (probability table), `seed` (seeded variation), `reasons` (all five rejection cases).

## Files changed

| File | Change |
|---|---|
| `src/shared/domain/sponsor-probability.ts` | **New** — probability functions, band labels, tier ranges, seeded RNG |
| `src/shared/domain/engines.ts` | Add `rejectionReason?` and `acceptanceProbability?` to `NegotiationEvaluationResult` |
| `src/shared/domain/types.ts` | Add `rejectionReason?` to `SponsorNegotiation` |
| `src/main/engines/evaluators/sponsor-evaluator.ts` | Probability model, seeded roll, rejection reasons, `getRivalConflictSponsorName` |
| `src/main/engines/negotiation-engine.ts` | Store `rejectionReason` on negotiation when transitioning to Failed |
| `src/main/services/game-state-manager.ts` | Auto-fail slot-filled PendingPlayerConfirmation negotiations on Sign |
| `src/renderer/content/Deals.tsx` | Browse signals, ContactModal overhaul, NegotiationCard rejection reason |
| `scripts/sim-sponsor-tier2.ts` | **New** — CLI test surface (band / seed / reasons) |

## Testing gate (for Tricia)

```
npx ts-node --compiler-options '{"module":"commonjs"}' scripts/sim-sponsor-tier2.ts
```

- **`band` scenario:** Prints probability + band for 9 payment ratios (0.50–1.20). Each row also shows the engine outcome and confirms `acceptanceProbability` matches the shared function — no parallel calculation.
- **`seed` scenario:** Runs 20 evaluations at `paymentRatio ≈ 0.95` (toss-up). Prints each seed → roll → outcome. Expects at least 2 distinct outcomes, confirming the seeded roll is live.
- **`reasons` scenario:** Triggers all five rejection cases and prints each `rejectionReason` string. Passes when all five are non-empty and match expected text.

Refs #244 — Tier 2 only. Tier 3 remains in scope under #244.