### PR TITLE
fix(sponsorship): ContactModal slider step was 1000x too large

### DIFF
--- a/src/renderer/content/sponsor-components.tsx
+++ b/src/renderer/content/sponsor-components.tsx
@@ -342,7 +342,7 @@ export function ContactModal({
   // Slider ranges
   const maxMonthly = sponsor.baseMonthlyPayment * 3;
   const maxBonus = sponsor.baseMonthlyPayment * 6;
-  const sliderStep = Math.max(1000, Math.round(sponsor.baseMonthlyPayment / 100) * 1000);
+  const sliderStep = Math.max(1000, Math.round(sponsor.baseMonthlyPayment / 100));
 
   const handleSubmit = () => {
     onSubmit({


### PR DESCRIPTION
## Summary

The ContactModal monthly-payment and signing-bonus sliders appeared frozen — drag did not change the value.

## Root cause

[sponsor-components.tsx:345](src/renderer/content/sponsor-components.tsx#L345):

\`\`\`ts
const sliderStep = Math.max(1000, Math.round(sponsor.baseMonthlyPayment / 100) * 1000);
\`\`\`

The \`* 1000\` after the round produces a step value of \`baseMonthlyPayment * 10\`, which is far larger than the slider's max (\`baseMonthlyPayment * 3\` for monthly, \`* 6\` for bonus). The slider has only one valid stopping point (0), so every drag snapped back.

## Fix

Drop the \`* 1000\`. Step is now \`Math.max(1000, Math.round(baseMonthlyPayment / 100))\` — ~300 smooth steps across the slider range.

## Why this slipped through

Pre-existing bug — present since Tier 1's ContactModal landed. Not caught because the manual drag test was deferred to the post-merge UI walkthrough that hasn't run yet. CLI gates can't validate slider draggability.

## Test plan

- [ ] Run \`npm run dev\`, open Sponsors → Browse → Contact on any sponsor
- [ ] Drag the Monthly Payment slider — value updates smoothly
- [ ] Drag the Signing Bonus slider — value updates smoothly
- [ ] Repeat from Renewals → Counter (modal pre-populated)

Hotfix merge expected immediately so the deferred UI walkthrough can finally run.