### PR TITLE
fix(sponsorship): surface inbox email when engine accepts player sponsor deal

### DIFF
--- a/src/main/services/negotiation-processor.ts
+++ b/src/main/services/negotiation-processor.ts
@@ -228,6 +228,19 @@ export function applyNegotiationUpdates(state: GameState, updates: NegotiationUp
             sponsorNeg.phase = NegotiationPhase.PendingPlayerConfirmation;
             state.negotiations[index] = sponsorNeg;
             shouldStop = true;
+
+            // Surface the acceptance via inbox so the player isn't stranded
+            // when the sim pauses. The signing celebration email still fires
+            // separately from generateSponsorSigningEvent after Sign is clicked.
+            const sponsor = state.sponsors.find((s) => s.id === sponsorNeg.sponsorId);
+            if (sponsor) {
+              generateNegotiationUpdateEmail(
+                state,
+                sponsor.name,
+                NegotiationPhase.Completed,
+                false
+              );
+            }
           } else {
             // AI teams: create the deal directly
             const contractResult = createSponsorContractFromNegotiation(sponsorNeg, state);


### PR DESCRIPTION
## Bug

When the engine accepts a player-team sponsor negotiation in `applyNegotiationUpdates`, the simulation pauses (`shouldStop = true`) but **no inbox email fires**. The player is stranded — sim halts with no surfaced reason and they must navigate to the Negotiations tab to discover the deal is awaiting their signature.

The companion email block at `negotiation-processor.ts:241` is intentionally guarded against `PendingPlayerConfirmation` to prevent a double-email after signing, so the engine's acceptance transition was silent.

Same gap affected accepts-after-counter and renewal accepts that go through engine simulation.

## Fix

Single missing call inserted at the transition point itself, inside the `isPlayerTeam && phase === Completed` branch in [negotiation-processor.ts](src/main/services/negotiation-processor.ts):

```ts
const sponsor = state.sponsors.find((s) => s.id === sponsorNeg.sponsorId);
if (sponsor) {
  generateNegotiationUpdateEmail(
    state,
    sponsor.name,
    NegotiationPhase.Completed,
    false
  );
}
```

- The phase passed (`Completed`) reflects the engine event being notified, not the post-mutation phase.
- The line-241 guard is unchanged — signing celebration email from `generateSponsorSigningEvent` still fires exactly once when the player clicks Sign.
- No changes to `signSponsorDeal`, `generateSponsorSigningEvent`, or the rejection/counter email paths.

Research note: `.agent/research.md` (accept-path audit by Rachel).

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- Existing rejection / counter / sign-confirmation emails unchanged (no duplication path introduced)